### PR TITLE
Implement Phase 2: Route Map & Waypoint Visualization

### DIFF
--- a/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
+++ b/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
@@ -52,6 +52,22 @@
 		LL001 /* LakeLouiseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = LL101 /* LakeLouiseService.swift */; };
 		LL002 /* LakeLouiseScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LL102 /* LakeLouiseScoreView.swift */; };
 		LLT01 /* LakeLouiseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LLT101 /* LakeLouiseServiceTests.swift */; };
+		RM001 /* DistanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM101 /* DistanceService.swift */; };
+		RM002 /* RouteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM102 /* RouteService.swift */; };
+		RM003 /* GPXService.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM103 /* GPXService.swift */; };
+		RM004 /* RouteMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM104 /* RouteMapViewModel.swift */; };
+		RM005 /* RouteMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM105 /* RouteMapView.swift */; };
+		RM006 /* WaypointMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM106 /* WaypointMarkerView.swift */; };
+		RM007 /* WaypointDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM107 /* WaypointDetailSheet.swift */; };
+		RM008 /* RouteMapOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM108 /* RouteMapOverlayView.swift */; };
+		RM009 /* GPXImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM109 /* GPXImportView.swift */; };
+		RMT01 /* DistanceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT101 /* DistanceServiceTests.swift */; };
+		RMT02 /* GPXServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT102 /* GPXServiceTests.swift */; };
+		RMT03 /* RouteServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT103 /* RouteServiceTests.swift */; };
+		RM010 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM110 /* LocationManager.swift */; };
+		RM011 /* ShelterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM111 /* ShelterService.swift */; };
+		RM012 /* MapCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM112 /* MapCacheService.swift */; };
+		RM013 /* RouteMapSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM113 /* RouteMapSheets.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +129,23 @@
 		LL101 /* LakeLouiseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LakeLouiseService.swift; sourceTree = "<group>"; };
 		LL102 /* LakeLouiseScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LakeLouiseScoreView.swift; sourceTree = "<group>"; };
 		LLT101 /* LakeLouiseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LakeLouiseServiceTests.swift; sourceTree = "<group>"; };
+		RM101 /* DistanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceService.swift; sourceTree = "<group>"; };
+		RM102 /* RouteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteService.swift; sourceTree = "<group>"; };
+		RM103 /* GPXService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXService.swift; sourceTree = "<group>"; };
+		RM104 /* RouteMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapViewModel.swift; sourceTree = "<group>"; };
+		RM105 /* RouteMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapView.swift; sourceTree = "<group>"; };
+		RM106 /* WaypointMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointMarkerView.swift; sourceTree = "<group>"; };
+		RM107 /* WaypointDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDetailSheet.swift; sourceTree = "<group>"; };
+		RM108 /* RouteMapOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapOverlayView.swift; sourceTree = "<group>"; };
+		RM109 /* GPXImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXImportView.swift; sourceTree = "<group>"; };
+		RMT101 /* DistanceServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceServiceTests.swift; sourceTree = "<group>"; };
+		RMT102 /* GPXServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXServiceTests.swift; sourceTree = "<group>"; };
+		RMT103 /* RouteServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteServiceTests.swift; sourceTree = "<group>"; };
+		RM110 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		RM111 /* ShelterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelterService.swift; sourceTree = "<group>"; };
+		RM112 /* MapCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCacheService.swift; sourceTree = "<group>"; };
+		RM113 /* RouteMapSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMapSheets.swift; sourceTree = "<group>"; };
+		119 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +191,7 @@
 				101 /* ExpeditionPlannerApp.swift */,
 				102 /* ContentView.swift */,
 				118 /* ExpeditionPlanner.entitlements */,
+				119 /* Info.plist */,
 				303 /* Models */,
 				304 /* Views */,
 				305 /* Utilities */,
@@ -199,8 +233,22 @@
 				307 /* Settings */,
 				D45F1224F8E4F52D45D017E2 /* Components */,
 				P2IT /* Itinerary */,
+				RMMAP /* Map */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		RMMAP /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				RM105 /* RouteMapView.swift */,
+				RM106 /* WaypointMarkerView.swift */,
+				RM107 /* WaypointDetailSheet.swift */,
+				RM108 /* RouteMapOverlayView.swift */,
+				RM109 /* GPXImportView.swift */,
+				RM113 /* RouteMapSheets.swift */,
+			);
+			path = Map;
 			sourceTree = "<group>";
 		};
 		305 /* Utilities */ = {
@@ -244,6 +292,12 @@
 				9466AF824266C9E22E26D382 /* SyncStatusService.swift */,
 				P2101 /* ElevationService.swift */,
 				LL101 /* LakeLouiseService.swift */,
+				RM101 /* DistanceService.swift */,
+				RM102 /* RouteService.swift */,
+				RM103 /* GPXService.swift */,
+				RM110 /* LocationManager.swift */,
+				RM111 /* ShelterService.swift */,
+				RM112 /* MapCacheService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -270,6 +324,9 @@
 				P2T101 /* ElevationServiceTests.swift */,
 				P2T102 /* ItineraryViewModelTests.swift */,
 				LLT101 /* LakeLouiseServiceTests.swift */,
+				RMT101 /* DistanceServiceTests.swift */,
+				RMT102 /* GPXServiceTests.swift */,
+				RMT103 /* RouteServiceTests.swift */,
 			);
 			path = ExpeditionPlannerTests;
 			sourceTree = "<group>";
@@ -279,6 +336,7 @@
 			children = (
 				P2102 /* ItineraryViewModel.swift */,
 				P2103 /* DayFormViewModel.swift */,
+				RM104 /* RouteMapViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -427,6 +485,19 @@
 				P2012 /* AcclimatizationWarningView.swift in Sources */,
 				LL001 /* LakeLouiseService.swift in Sources */,
 				LL002 /* LakeLouiseScoreView.swift in Sources */,
+				RM001 /* DistanceService.swift in Sources */,
+				RM002 /* RouteService.swift in Sources */,
+				RM003 /* GPXService.swift in Sources */,
+				RM004 /* RouteMapViewModel.swift in Sources */,
+				RM005 /* RouteMapView.swift in Sources */,
+				RM006 /* WaypointMarkerView.swift in Sources */,
+				RM007 /* WaypointDetailSheet.swift in Sources */,
+				RM008 /* RouteMapOverlayView.swift in Sources */,
+				RM009 /* GPXImportView.swift in Sources */,
+				RM010 /* LocationManager.swift in Sources */,
+				RM011 /* ShelterService.swift in Sources */,
+				RM012 /* MapCacheService.swift in Sources */,
+				RM013 /* RouteMapSheets.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,6 +516,9 @@
 				P2T01 /* ElevationServiceTests.swift in Sources */,
 				P2T02 /* ItineraryViewModelTests.swift in Sources */,
 				LLT01 /* LakeLouiseServiceTests.swift in Sources */,
+				RMT01 /* DistanceServiceTests.swift in Sources */,
+				RMT02 /* GPXServiceTests.swift in Sources */,
+				RMT03 /* RouteServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -628,6 +702,7 @@
 				DEVELOPMENT_TEAM = L8C6ADCNAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ExpeditionPlanner/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -658,6 +733,7 @@
 				DEVELOPMENT_TEAM = L8C6ADCNAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ExpeditionPlanner/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ExpeditionPlanner/ExpeditionPlanner/Info.plist
+++ b/ExpeditionPlanner/ExpeditionPlanner/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Expedition Planner uses your location to show your position on the route map and track your progress during expeditions.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Expedition Planner uses your location to track your progress during expeditions, even when the app is in the background.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+</dict>
+</plist>

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/DistanceService.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/DistanceService.swift
@@ -1,0 +1,193 @@
+import Foundation
+import CoreLocation
+
+struct DistanceService {
+    // MARK: - Constants
+
+    static let metersPerKilometer: Double = 1000.0
+    static let metersPerMile: Double = 1609.344
+    static let feetPerMeter: Double = 3.28084
+
+    // MARK: - Distance Calculations
+
+    /// Calculate geodesic distance between two coordinates
+    static func distance(
+        from start: CLLocationCoordinate2D,
+        to end: CLLocationCoordinate2D
+    ) -> CLLocationDistance {
+        let startLocation = CLLocation(latitude: start.latitude, longitude: start.longitude)
+        let endLocation = CLLocation(latitude: end.latitude, longitude: end.longitude)
+        return startLocation.distance(from: endLocation)
+    }
+
+    /// Calculate total distance along a route of coordinates
+    static func totalDistance(along coordinates: [CLLocationCoordinate2D]) -> CLLocationDistance {
+        guard coordinates.count >= 2 else { return 0 }
+
+        var total: CLLocationDistance = 0
+        for index in 0..<(coordinates.count - 1) {
+            total += distance(from: coordinates[index], to: coordinates[index + 1])
+        }
+        return total
+    }
+
+    /// Calculate distance from a point to the nearest point on a line segment
+    static func distanceToSegment(
+        point: CLLocationCoordinate2D,
+        segmentStart: CLLocationCoordinate2D,
+        segmentEnd: CLLocationCoordinate2D
+    ) -> CLLocationDistance {
+        let pointLoc = CLLocation(latitude: point.latitude, longitude: point.longitude)
+        let startLoc = CLLocation(latitude: segmentStart.latitude, longitude: segmentStart.longitude)
+        let endLoc = CLLocation(latitude: segmentEnd.latitude, longitude: segmentEnd.longitude)
+
+        let segmentLength = startLoc.distance(from: endLoc)
+        guard segmentLength > 0 else {
+            return pointLoc.distance(from: startLoc)
+        }
+
+        // Project point onto segment
+        let param = max(0, min(1, projection(point: point, onto: (segmentStart, segmentEnd))))
+        let projectedLat = segmentStart.latitude + param * (segmentEnd.latitude - segmentStart.latitude)
+        let projectedLon = segmentStart.longitude + param * (segmentEnd.longitude - segmentStart.longitude)
+        let projectedLoc = CLLocation(latitude: projectedLat, longitude: projectedLon)
+
+        return pointLoc.distance(from: projectedLoc)
+    }
+
+    /// Calculate the projection parameter t for a point onto a line segment
+    private static func projection(
+        point: CLLocationCoordinate2D,
+        onto segment: (CLLocationCoordinate2D, CLLocationCoordinate2D)
+    ) -> Double {
+        let (start, end) = segment
+        let dx = end.longitude - start.longitude
+        let dy = end.latitude - start.latitude
+
+        guard dx != 0 || dy != 0 else { return 0 }
+
+        let param = ((point.longitude - start.longitude) * dx + (point.latitude - start.latitude) * dy)
+            / (dx * dx + dy * dy)
+
+        return param
+    }
+
+    // MARK: - Bearing Calculations
+
+    /// Calculate initial bearing from start to end coordinate
+    static func bearing(
+        from start: CLLocationCoordinate2D,
+        to end: CLLocationCoordinate2D
+    ) -> Double {
+        let lat1 = start.latitude * .pi / 180
+        let lat2 = end.latitude * .pi / 180
+        let dLon = (end.longitude - start.longitude) * .pi / 180
+
+        let y = sin(dLon) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+
+        var bearing = atan2(y, x) * 180 / .pi
+        bearing = (bearing + 360).truncatingRemainder(dividingBy: 360)
+
+        return bearing
+    }
+
+    /// Convert bearing to cardinal direction
+    static func cardinalDirection(from bearing: Double) -> String {
+        let directions = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+                          "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"]
+        let index = Int((bearing + 11.25) / 22.5) % 16
+        return directions[index]
+    }
+
+    // MARK: - Unit Conversion
+
+    static func metersToKilometers(_ meters: Double) -> Double {
+        meters / metersPerKilometer
+    }
+
+    static func metersToMiles(_ meters: Double) -> Double {
+        meters / metersPerMile
+    }
+
+    static func kilometersToMeters(_ km: Double) -> Double {
+        km * metersPerKilometer
+    }
+
+    static func milesToMeters(_ miles: Double) -> Double {
+        miles * metersPerMile
+    }
+
+    // MARK: - Formatting
+
+    static func formatDistance(_ meters: Double, useMetric: Bool = true) -> String {
+        if useMetric {
+            if meters >= 1000 {
+                return String(format: "%.1f km", metersToKilometers(meters))
+            } else {
+                return String(format: "%.0f m", meters)
+            }
+        } else {
+            let miles = metersToMiles(meters)
+            if miles >= 0.1 {
+                return String(format: "%.1f mi", miles)
+            } else {
+                let feet = meters * feetPerMeter
+                return String(format: "%.0f ft", feet)
+            }
+        }
+    }
+
+    static func formatBearing(_ bearing: Double) -> String {
+        let cardinal = cardinalDirection(from: bearing)
+        return String(format: "%.0f° %@", bearing, cardinal)
+    }
+
+    // MARK: - Bounding Box
+
+    struct BoundingBox {
+        let minLatitude: Double
+        let maxLatitude: Double
+        let minLongitude: Double
+        let maxLongitude: Double
+
+        var center: CLLocationCoordinate2D {
+            CLLocationCoordinate2D(
+                latitude: (minLatitude + maxLatitude) / 2,
+                longitude: (minLongitude + maxLongitude) / 2
+            )
+        }
+
+        var latitudeSpan: Double {
+            maxLatitude - minLatitude
+        }
+
+        var longitudeSpan: Double {
+            maxLongitude - minLongitude
+        }
+    }
+
+    /// Calculate bounding box for a set of coordinates
+    static func boundingBox(for coordinates: [CLLocationCoordinate2D]) -> BoundingBox? {
+        guard !coordinates.isEmpty else { return nil }
+
+        var minLat = coordinates[0].latitude
+        var maxLat = coordinates[0].latitude
+        var minLon = coordinates[0].longitude
+        var maxLon = coordinates[0].longitude
+
+        for coord in coordinates {
+            minLat = min(minLat, coord.latitude)
+            maxLat = max(maxLat, coord.latitude)
+            minLon = min(minLon, coord.longitude)
+            maxLon = max(maxLon, coord.longitude)
+        }
+
+        return BoundingBox(
+            minLatitude: minLat,
+            maxLatitude: maxLat,
+            minLongitude: minLon,
+            maxLongitude: maxLon
+        )
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/GPXService.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/GPXService.swift
@@ -1,0 +1,302 @@
+import Foundation
+import CoreLocation
+
+// MARK: - GPX Service
+
+struct GPXService {
+    // MARK: - GPX Parsing
+
+    struct GPXParseResult {
+        let waypoints: [RouteWaypoint]
+        let trackPoints: [CLLocationCoordinate2D]
+        let name: String?
+        let description: String?
+    }
+
+    /// Parse GPX data into waypoints and track points
+    static func parse(data: Data) -> GPXParseResult? {
+        let parser = GPXParser(data: data)
+        return parser.parse()
+    }
+
+    /// Parse GPX from a URL
+    static func parse(url: URL) -> GPXParseResult? {
+        guard let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return parse(data: data)
+    }
+
+    // MARK: - GPX Export
+
+    /// Export waypoints and track to GPX 1.1 format
+    static func export(
+        waypoints: [RouteWaypoint],
+        trackCoordinates: [CLLocationCoordinate2D],
+        name: String? = nil,
+        description: String? = nil
+    ) -> String {
+        var gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="ExpeditionPlanner"
+             xmlns="http://www.topografix.com/GPX/1/1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+        """
+
+        // Metadata
+        if let name {
+            gpx += "\n  <metadata>\n    <name>\(escapeXML(name))</name>"
+            if let description {
+                gpx += "\n    <desc>\(escapeXML(description))</desc>"
+            }
+            gpx += "\n    <time>\(ISO8601DateFormatter().string(from: Date()))</time>"
+            gpx += "\n  </metadata>"
+        }
+
+        // Waypoints
+        for waypoint in waypoints {
+            gpx += "\n  <wpt lat=\"\(waypoint.coordinate.latitude)\" lon=\"\(waypoint.coordinate.longitude)\">"
+            if let elevation = waypoint.elevationMeters {
+                gpx += "\n    <ele>\(elevation)</ele>"
+            }
+            gpx += "\n    <name>\(escapeXML(waypoint.name))</name>"
+            gpx += "\n    <type>\(escapeXML(waypoint.type.rawValue))</type>"
+            if let notes = waypoint.notes {
+                gpx += "\n    <desc>\(escapeXML(notes))</desc>"
+            }
+            gpx += "\n  </wpt>"
+        }
+
+        // Track
+        if !trackCoordinates.isEmpty {
+            gpx += "\n  <trk>"
+            if let name {
+                gpx += "\n    <name>\(escapeXML(name)) Track</name>"
+            }
+            gpx += "\n    <trkseg>"
+
+            for coord in trackCoordinates {
+                gpx += "\n      <trkpt lat=\"\(coord.latitude)\" lon=\"\(coord.longitude)\"/>"
+            }
+
+            gpx += "\n    </trkseg>"
+            gpx += "\n  </trk>"
+        }
+
+        gpx += "\n</gpx>\n"
+
+        return gpx
+    }
+
+    /// Export to a file URL
+    static func export(
+        waypoints: [RouteWaypoint],
+        trackCoordinates: [CLLocationCoordinate2D],
+        name: String,
+        to url: URL
+    ) throws {
+        let gpxString = export(
+            waypoints: waypoints,
+            trackCoordinates: trackCoordinates,
+            name: name
+        )
+        try gpxString.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Helpers
+
+    private static func escapeXML(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}
+
+// MARK: - GPX Parser
+
+private class GPXParser: NSObject, XMLParserDelegate {
+    private let parser: XMLParser
+    private var waypoints: [RouteWaypoint] = []
+    private var trackPoints: [CLLocationCoordinate2D] = []
+    private var gpxName: String?
+    private var gpxDescription: String?
+
+    // Current parsing state
+    private var currentElement: String = ""
+    private var currentText: String = ""
+
+    // Current waypoint data
+    private var currentLat: Double?
+    private var currentLon: Double?
+    private var currentElevation: Double?
+    private var currentName: String?
+    private var currentType: String?
+    private var currentDesc: String?
+
+    // Track state
+    private var inTrack = false
+    private var inTrackSegment = false
+
+    init(data: Data) {
+        self.parser = XMLParser(data: data)
+        super.init()
+        parser.delegate = self
+    }
+
+    func parse() -> GPXService.GPXParseResult? {
+        guard parser.parse() else {
+            return nil
+        }
+
+        return GPXService.GPXParseResult(
+            waypoints: waypoints,
+            trackPoints: trackPoints,
+            name: gpxName,
+            description: gpxDescription
+        )
+    }
+
+    // MARK: - XMLParserDelegate
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        currentElement = elementName
+        currentText = ""
+
+        switch elementName {
+        case "wpt", "trkpt":
+            currentLat = Double(attributeDict["lat"] ?? "")
+            currentLon = Double(attributeDict["lon"] ?? "")
+            currentElevation = nil
+            currentName = nil
+            currentType = nil
+            currentDesc = nil
+
+        case "trk":
+            inTrack = true
+
+        case "trkseg":
+            inTrackSegment = true
+
+        default:
+            break
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        currentText += string
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        let trimmedText = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch elementName {
+        case "name":
+            if inTrack {
+                // Track name, ignore for now
+            } else if currentLat != nil {
+                currentName = trimmedText
+            } else {
+                gpxName = trimmedText
+            }
+
+        case "desc":
+            if currentLat != nil {
+                currentDesc = trimmedText
+            } else {
+                gpxDescription = trimmedText
+            }
+
+        case "ele":
+            currentElevation = Double(trimmedText)
+
+        case "type":
+            currentType = trimmedText
+
+        case "wpt":
+            if let lat = currentLat, let lon = currentLon {
+                let waypointType = parseWaypointType(currentType)
+                let waypoint = RouteWaypoint(
+                    coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+                    name: currentName ?? "Waypoint",
+                    type: waypointType,
+                    elevationMeters: currentElevation,
+                    notes: currentDesc,
+                    sourceId: UUID()
+                )
+                waypoints.append(waypoint)
+            }
+            resetCurrentWaypoint()
+
+        case "trkpt":
+            if let lat = currentLat, let lon = currentLon {
+                trackPoints.append(CLLocationCoordinate2D(latitude: lat, longitude: lon))
+            }
+            resetCurrentWaypoint()
+
+        case "trkseg":
+            inTrackSegment = false
+
+        case "trk":
+            inTrack = false
+
+        default:
+            break
+        }
+
+        currentElement = ""
+    }
+
+    private func resetCurrentWaypoint() {
+        currentLat = nil
+        currentLon = nil
+        currentElevation = nil
+        currentName = nil
+        currentType = nil
+        currentDesc = nil
+    }
+
+    private func parseWaypointType(_ typeString: String?) -> WaypointType {
+        guard let typeString = typeString?.lowercased() else {
+            return .waypoint
+        }
+
+        // Try to match known types
+        switch typeString {
+        case "start", "start point", "trailhead":
+            return .startPoint
+        case "end", "end point", "finish":
+            return .endPoint
+        case "camp", "campsite", "camping":
+            return .campsite
+        case "resupply", "supply":
+            return .resupply
+        case "summit", "peak":
+            return .summit
+        case "hazard", "danger", "warning":
+            return .hazard
+        case "shelter", "cabin", "hut", "refuge":
+            return .shelter
+        default:
+            // Check if any WaypointType rawValue matches
+            if let matchedType = WaypointType.allCases.first(where: { $0.rawValue.lowercased() == typeString }) {
+                return matchedType
+            }
+            return .waypoint
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/LocationManager.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/LocationManager.swift
@@ -1,0 +1,236 @@
+import Foundation
+import CoreLocation
+import Combine
+
+/// Manages location services for expedition tracking
+@Observable
+final class LocationManager: NSObject {
+    // MARK: - Properties
+
+    private let locationManager = CLLocationManager()
+
+    /// Current user location
+    private(set) var currentLocation: CLLocation?
+
+    /// Current authorization status
+    private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
+    /// Whether location is currently being tracked
+    private(set) var isTracking = false
+
+    /// Recorded track points during tracking session
+    private(set) var trackPoints: [CLLocation] = []
+
+    /// Total distance traveled in current tracking session (meters)
+    var distanceTraveled: CLLocationDistance {
+        guard trackPoints.count >= 2 else { return 0 }
+        var total: CLLocationDistance = 0
+        for index in 1..<trackPoints.count {
+            total += trackPoints[index].distance(from: trackPoints[index - 1])
+        }
+        return total
+    }
+
+    /// Current speed in meters per second
+    var currentSpeed: CLLocationSpeed {
+        currentLocation?.speed ?? 0
+    }
+
+    /// Current heading in degrees
+    var currentHeading: CLLocationDirection {
+        currentLocation?.course ?? -1
+    }
+
+    /// Whether location services are authorized
+    var isAuthorized: Bool {
+        switch authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether location services are denied
+    var isDenied: Bool {
+        authorizationStatus == .denied
+    }
+
+    /// Human-readable authorization status
+    var authorizationStatusDescription: String {
+        switch authorizationStatus {
+        case .notDetermined:
+            return "Not Determined"
+        case .restricted:
+            return "Restricted"
+        case .denied:
+            return "Denied"
+        case .authorizedAlways:
+            return "Always"
+        case .authorizedWhenInUse:
+            return "When In Use"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    // MARK: - Initialization
+
+    override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 10 // Update every 10 meters
+        locationManager.allowsBackgroundLocationUpdates = false
+        locationManager.pausesLocationUpdatesAutomatically = true
+        authorizationStatus = locationManager.authorizationStatus
+    }
+
+    // MARK: - Authorization
+
+    /// Request location authorization
+    func requestAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+
+    /// Request always authorization (for background tracking)
+    func requestAlwaysAuthorization() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    // MARK: - Location Updates
+
+    /// Start receiving location updates
+    func startUpdatingLocation() {
+        guard isAuthorized else {
+            requestAuthorization()
+            return
+        }
+        locationManager.startUpdatingLocation()
+    }
+
+    /// Stop receiving location updates
+    func stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
+    }
+
+    /// Request a single location update
+    func requestLocation() {
+        guard isAuthorized else {
+            requestAuthorization()
+            return
+        }
+        locationManager.requestLocation()
+    }
+
+    // MARK: - Tracking
+
+    /// Start tracking expedition progress
+    func startTracking() {
+        guard isAuthorized else {
+            requestAuthorization()
+            return
+        }
+
+        trackPoints.removeAll()
+        isTracking = true
+        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.startUpdatingLocation()
+    }
+
+    /// Stop tracking and return the recorded track
+    func stopTracking() -> [CLLocation] {
+        isTracking = false
+        locationManager.allowsBackgroundLocationUpdates = false
+        locationManager.stopUpdatingLocation()
+        return trackPoints
+    }
+
+    /// Pause tracking temporarily
+    func pauseTracking() {
+        isTracking = false
+        locationManager.stopUpdatingLocation()
+    }
+
+    /// Resume tracking
+    func resumeTracking() {
+        guard !trackPoints.isEmpty else {
+            startTracking()
+            return
+        }
+        isTracking = true
+        locationManager.startUpdatingLocation()
+    }
+
+    /// Clear recorded track points
+    func clearTrack() {
+        trackPoints.removeAll()
+    }
+
+    // MARK: - Utilities
+
+    /// Calculate distance from current location to a coordinate
+    func distanceTo(_ coordinate: CLLocationCoordinate2D) -> CLLocationDistance? {
+        guard let current = currentLocation else { return nil }
+        let destination = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        return current.distance(from: destination)
+    }
+
+    /// Calculate bearing from current location to a coordinate
+    func bearingTo(_ coordinate: CLLocationCoordinate2D) -> Double? {
+        guard let current = currentLocation else { return nil }
+        return DistanceService.bearing(from: current.coordinate, to: coordinate)
+    }
+
+    /// Get track points as coordinates for map display
+    var trackCoordinates: [CLLocationCoordinate2D] {
+        trackPoints.map { $0.coordinate }
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        // Filter out inaccurate locations
+        guard location.horizontalAccuracy >= 0 && location.horizontalAccuracy < 100 else { return }
+
+        currentLocation = location
+
+        if isTracking {
+            // Only add point if it's significantly different from the last one
+            if let lastPoint = trackPoints.last {
+                let distance = location.distance(from: lastPoint)
+                if distance >= 5 { // Minimum 5 meters between track points
+                    trackPoints.append(location)
+                }
+            } else {
+                trackPoints.append(location)
+            }
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Handle location errors silently for now
+        // In production, you might want to notify the user
+        if let clError = error as? CLError {
+            switch clError.code {
+            case .denied:
+                authorizationStatus = .denied
+            default:
+                break
+            }
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+
+        // Automatically start updates if authorized and tracking was requested
+        if isAuthorized && isTracking {
+            locationManager.startUpdatingLocation()
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/MapCacheService.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/MapCacheService.swift
@@ -1,0 +1,376 @@
+import Foundation
+import MapKit
+import OSLog
+
+private let logger = Logger(subsystem: "com.expedition.planner", category: "MapCacheService")
+
+/// Represents a tile coordinate in the slippy map system
+struct TileCoordinate {
+    let tileX: Int
+    let tileY: Int
+    let zoom: Int
+}
+
+/// Service for managing offline map tile caching
+final class MapCacheService: NSObject, ObservableObject {
+    // MARK: - Properties
+
+    static let shared = MapCacheService()
+
+    @Published private(set) var isDownloading = false
+    @Published private(set) var downloadProgress: Double = 0
+    @Published private(set) var cachedRegions: [CachedRegion] = []
+    @Published private(set) var totalCacheSize: Int64 = 0
+
+    private let fileManager = FileManager.default
+    private var downloadTask: URLSessionDataTask?
+    private var tilesToDownload: [TileCoordinate] = []
+    private var tilesDownloaded = 0
+    private var currentRegionName = ""
+
+    // MARK: - Cache Directory
+
+    private var cacheDirectory: URL {
+        let paths = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)
+        let cacheDir = paths[0].appendingPathComponent("MapTiles", isDirectory: true)
+
+        if !fileManager.fileExists(atPath: cacheDir.path) {
+            try? fileManager.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        }
+
+        return cacheDir
+    }
+
+    private var regionsFile: URL {
+        cacheDirectory.appendingPathComponent("regions.json")
+    }
+
+    // MARK: - Initialization
+
+    override private init() {
+        super.init()
+        loadCachedRegions()
+        calculateCacheSize()
+    }
+
+    // MARK: - Cached Region Model
+
+    struct CachedRegion: Codable, Identifiable {
+        let id: UUID
+        let name: String
+        let centerLatitude: Double
+        let centerLongitude: Double
+        let spanLatitude: Double
+        let spanLongitude: Double
+        let minZoom: Int
+        let maxZoom: Int
+        let tileCount: Int
+        let downloadedAt: Date
+        var sizeBytes: Int64
+
+        var region: MKCoordinateRegion {
+            MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude),
+                span: MKCoordinateSpan(latitudeDelta: spanLatitude, longitudeDelta: spanLongitude)
+            )
+        }
+
+        var formattedSize: String {
+            ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        }
+    }
+
+    // MARK: - Download Region
+
+    /// Download map tiles for a region
+    func downloadRegion(
+        name: String,
+        region: MKCoordinateRegion,
+        minZoom: Int = 10,
+        maxZoom: Int = 15
+    ) async throws {
+        guard !isDownloading else {
+            throw MapCacheError.alreadyDownloading
+        }
+
+        await MainActor.run {
+            isDownloading = true
+            downloadProgress = 0
+            currentRegionName = name
+        }
+
+        defer {
+            Task { @MainActor in
+                isDownloading = false
+            }
+        }
+
+        // Calculate tiles needed
+        let tiles = calculateTiles(for: region, minZoom: minZoom, maxZoom: maxZoom)
+        let totalTiles = tiles.count
+
+        guard totalTiles > 0 else {
+            throw MapCacheError.noTilesToDownload
+        }
+
+        logger.info("Starting download of \(totalTiles) tiles for region: \(name)")
+
+        var downloadedCount = 0
+        var totalSize: Int64 = 0
+
+        // Download tiles
+        for tile in tiles {
+            do {
+                let size = try await downloadTile(x: tile.tileX, y: tile.tileY, zoom: tile.zoom)
+                totalSize += size
+                downloadedCount += 1
+
+                let progress = Double(downloadedCount) / Double(totalTiles)
+                await MainActor.run {
+                    downloadProgress = progress
+                }
+            } catch {
+                let logMsg = "Failed to download tile (\(tile.tileX), \(tile.tileY), \(tile.zoom))"
+                logger.warning("\(logMsg): \(error)")
+                // Continue with other tiles
+            }
+        }
+
+        // Save region metadata
+        let cachedRegion = CachedRegion(
+            id: UUID(),
+            name: name,
+            centerLatitude: region.center.latitude,
+            centerLongitude: region.center.longitude,
+            spanLatitude: region.span.latitudeDelta,
+            spanLongitude: region.span.longitudeDelta,
+            minZoom: minZoom,
+            maxZoom: maxZoom,
+            tileCount: downloadedCount,
+            downloadedAt: Date(),
+            sizeBytes: totalSize
+        )
+
+        await MainActor.run {
+            cachedRegions.append(cachedRegion)
+            saveCachedRegions()
+            calculateCacheSize()
+        }
+
+        logger.info("Downloaded \(downloadedCount) tiles (\(cachedRegion.formattedSize)) for region: \(name)")
+    }
+
+    // MARK: - Tile Calculation
+
+    private func calculateTiles(
+        for region: MKCoordinateRegion,
+        minZoom: Int,
+        maxZoom: Int
+    ) -> [TileCoordinate] {
+        var tiles: [TileCoordinate] = []
+
+        let minLat = region.center.latitude - region.span.latitudeDelta / 2
+        let maxLat = region.center.latitude + region.span.latitudeDelta / 2
+        let minLon = region.center.longitude - region.span.longitudeDelta / 2
+        let maxLon = region.center.longitude + region.span.longitudeDelta / 2
+
+        for zoom in minZoom...maxZoom {
+            let minTileX = lonToTileX(minLon, zoom: zoom)
+            let maxTileX = lonToTileX(maxLon, zoom: zoom)
+            let minTileY = latToTileY(maxLat, zoom: zoom) // Note: Y is inverted
+            let maxTileY = latToTileY(minLat, zoom: zoom)
+
+            for xCoord in minTileX...maxTileX {
+                for yCoord in minTileY...maxTileY {
+                    tiles.append(TileCoordinate(tileX: xCoord, tileY: yCoord, zoom: zoom))
+                }
+            }
+        }
+
+        return tiles
+    }
+
+    private func lonToTileX(_ lon: Double, zoom: Int) -> Int {
+        return Int(floor((lon + 180.0) / 360.0 * pow(2.0, Double(zoom))))
+    }
+
+    private func latToTileY(_ lat: Double, zoom: Int) -> Int {
+        let latRad = lat * .pi / 180.0
+        return Int(floor((1.0 - log(tan(latRad) + 1.0 / cos(latRad)) / .pi) / 2.0 * pow(2.0, Double(zoom))))
+    }
+
+    // MARK: - Tile Download
+
+    private func downloadTile(x: Int, y: Int, zoom: Int) async throws -> Int64 {
+        // Check if already cached
+        let tilePath = tilePath(x: x, y: y, zoom: zoom)
+        if fileManager.fileExists(atPath: tilePath.path) {
+            let attrs = try fileManager.attributesOfItem(atPath: tilePath.path)
+            return attrs[.size] as? Int64 ?? 0
+        }
+
+        // Download from OpenStreetMap
+        let urlString = "https://tile.openstreetmap.org/\(zoom)/\(x)/\(y).png"
+        guard let url = URL(string: urlString) else {
+            throw MapCacheError.invalidTileURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("ExpeditionPlanner/1.0", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw MapCacheError.downloadFailed
+        }
+
+        // Create directory structure
+        let tileDir = tilePath.deletingLastPathComponent()
+        try fileManager.createDirectory(at: tileDir, withIntermediateDirectories: true)
+
+        // Save tile
+        try data.write(to: tilePath)
+
+        return Int64(data.count)
+    }
+
+    // MARK: - Tile Path
+
+    func tilePath(x: Int, y: Int, zoom: Int) -> URL {
+        cacheDirectory
+            .appendingPathComponent("\(zoom)", isDirectory: true)
+            .appendingPathComponent("\(x)", isDirectory: true)
+            .appendingPathComponent("\(y).png")
+    }
+
+    /// Check if a tile is cached
+    func hasCachedTile(x: Int, y: Int, zoom: Int) -> Bool {
+        fileManager.fileExists(atPath: tilePath(x: x, y: y, zoom: zoom).path)
+    }
+
+    /// Get cached tile data
+    func cachedTileData(x: Int, y: Int, zoom: Int) -> Data? {
+        try? Data(contentsOf: tilePath(x: x, y: y, zoom: zoom))
+    }
+
+    // MARK: - Cache Management
+
+    /// Delete a cached region
+    func deleteRegion(_ region: CachedRegion) {
+        cachedRegions.removeAll { $0.id == region.id }
+        saveCachedRegions()
+        calculateCacheSize()
+    }
+
+    /// Clear all cached tiles
+    func clearCache() {
+        try? fileManager.removeItem(at: cacheDirectory)
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        cachedRegions.removeAll()
+        saveCachedRegions()
+        totalCacheSize = 0
+        logger.info("Map cache cleared")
+    }
+
+    /// Calculate total cache size
+    func calculateCacheSize() {
+        var size: Int64 = 0
+
+        if let enumerator = fileManager.enumerator(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            while let fileURL = enumerator.nextObject() as? URL {
+                if let attrs = try? fileManager.attributesOfItem(atPath: fileURL.path),
+                   let fileSize = attrs[.size] as? Int64 {
+                    size += fileSize
+                }
+            }
+        }
+
+        totalCacheSize = size
+    }
+
+    var formattedCacheSize: String {
+        ByteCountFormatter.string(fromByteCount: totalCacheSize, countStyle: .file)
+    }
+
+    // MARK: - Persistence
+
+    private func loadCachedRegions() {
+        guard fileManager.fileExists(atPath: regionsFile.path) else { return }
+
+        do {
+            let data = try Data(contentsOf: regionsFile)
+            cachedRegions = try JSONDecoder().decode([CachedRegion].self, from: data)
+        } catch {
+            logger.error("Failed to load cached regions: \(error)")
+        }
+    }
+
+    private func saveCachedRegions() {
+        do {
+            let data = try JSONEncoder().encode(cachedRegions)
+            try data.write(to: regionsFile)
+        } catch {
+            logger.error("Failed to save cached regions: \(error)")
+        }
+    }
+
+    // MARK: - Errors
+
+    enum MapCacheError: LocalizedError {
+        case alreadyDownloading
+        case noTilesToDownload
+        case invalidTileURL
+        case downloadFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .alreadyDownloading:
+                return "A download is already in progress"
+            case .noTilesToDownload:
+                return "No tiles to download for the specified region"
+            case .invalidTileURL:
+                return "Invalid tile URL"
+            case .downloadFailed:
+                return "Failed to download tile"
+            }
+        }
+    }
+}
+
+// MARK: - Cached Tile Overlay
+
+/// Custom tile overlay that serves cached tiles
+class CachedTileOverlay: MKTileOverlay {
+    private let cacheService = MapCacheService.shared
+
+    override func url(forTilePath path: MKTileOverlayPath) -> URL {
+        // Return cached tile path if available
+        let tilePath = cacheService.tilePath(x: path.x, y: path.y, zoom: path.z)
+        if FileManager.default.fileExists(atPath: tilePath.path) {
+            return tilePath
+        }
+
+        // Fall back to online tile
+        // swiftlint:disable:next force_unwrapping
+        return URL(string: "https://tile.openstreetmap.org/\(path.z)/\(path.x)/\(path.y).png")!
+    }
+
+    override func loadTile(
+        at path: MKTileOverlayPath,
+        result: @escaping (Data?, Error?) -> Void
+    ) {
+        // Try cached tile first
+        if let data = cacheService.cachedTileData(x: path.x, y: path.y, zoom: path.z) {
+            result(data, nil)
+            return
+        }
+
+        // Fall back to downloading
+        super.loadTile(at: path, result: result)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/RouteService.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/RouteService.swift
@@ -1,0 +1,340 @@
+import Foundation
+import CoreLocation
+import SwiftUI
+
+// MARK: - Waypoint Type
+
+enum WaypointType: String, CaseIterable, Codable {
+    case startPoint = "Start Point"
+    case endPoint = "End Point"
+    case campsite = "Campsite"
+    case resupply = "Resupply"
+    case trailhead = "Trailhead"
+    case summit = "Summit"
+    case hazard = "Hazard"
+    case shelter = "Shelter"
+    case waypoint = "Waypoint"
+
+    var icon: String {
+        switch self {
+        case .startPoint:
+            return "flag.fill"
+        case .endPoint:
+            return "flag.checkered"
+        case .campsite:
+            return "tent.fill"
+        case .resupply:
+            return "shippingbox.fill"
+        case .trailhead:
+            return "figure.hiking"
+        case .summit:
+            return "mountain.2.fill"
+        case .hazard:
+            return "exclamationmark.triangle.fill"
+        case .shelter:
+            return "house.fill"
+        case .waypoint:
+            return "mappin"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .startPoint:
+            return .green
+        case .endPoint:
+            return .red
+        case .campsite:
+            return .indigo
+        case .resupply:
+            return .brown
+        case .trailhead:
+            return .blue
+        case .summit:
+            return .orange
+        case .hazard:
+            return .yellow
+        case .shelter:
+            return .teal
+        case .waypoint:
+            return .gray
+        }
+    }
+
+    var sortOrder: Int {
+        switch self {
+        case .startPoint: return 0
+        case .endPoint: return 1
+        case .summit: return 2
+        case .hazard: return 3
+        case .resupply: return 4
+        case .trailhead: return 5
+        case .shelter: return 6
+        case .campsite: return 7
+        case .waypoint: return 8
+        }
+    }
+}
+
+// MARK: - Route Waypoint
+
+struct RouteWaypoint: Identifiable, Hashable {
+    let id: UUID
+    let coordinate: CLLocationCoordinate2D
+    let name: String
+    let type: WaypointType
+    let elevationMeters: Double?
+    let dayNumber: Int?
+    let date: Date?
+    let notes: String?
+    let sourceId: UUID
+
+    init(
+        id: UUID = UUID(),
+        coordinate: CLLocationCoordinate2D,
+        name: String,
+        type: WaypointType,
+        elevationMeters: Double? = nil,
+        dayNumber: Int? = nil,
+        date: Date? = nil,
+        notes: String? = nil,
+        sourceId: UUID
+    ) {
+        self.id = id
+        self.coordinate = coordinate
+        self.name = name
+        self.type = type
+        self.elevationMeters = elevationMeters
+        self.dayNumber = dayNumber
+        self.date = date
+        self.notes = notes
+        self.sourceId = sourceId
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+// MARK: - Route Service
+
+struct RouteService {
+    // MARK: - Waypoint Extraction
+
+    /// Extract waypoints from itinerary days
+    static func extractWaypoints(from days: [ItineraryDay]) -> [RouteWaypoint] {
+        var waypoints: [RouteWaypoint] = []
+        let sortedDays = days.sorted { $0.dayNumber < $1.dayNumber }
+
+        for (index, day) in sortedDays.enumerated() {
+            // Start point of first day
+            if index == 0, let coord = day.startCoordinate {
+                let waypoint = RouteWaypoint(
+                    coordinate: coord,
+                    name: day.startLocation.isEmpty ? "Start" : day.startLocation,
+                    type: .startPoint,
+                    elevationMeters: day.startElevationMeters,
+                    dayNumber: day.dayNumber,
+                    date: day.date,
+                    sourceId: day.id
+                )
+                waypoints.append(waypoint)
+            }
+
+            // End point of each day (campsite or endpoint for last day)
+            if let coord = day.endCoordinate {
+                let isLastDay = index == sortedDays.count - 1
+                let isCampsite = day.campName != nil || day.nightNumber != nil
+
+                let type: WaypointType
+                if isLastDay {
+                    type = .endPoint
+                } else if day.activityType == .summit {
+                    type = .summit
+                } else if isCampsite {
+                    type = .campsite
+                } else {
+                    type = .waypoint
+                }
+
+                let name: String
+                if !day.endLocation.isEmpty {
+                    name = day.endLocation
+                } else if let campName = day.campName, !campName.isEmpty {
+                    name = campName
+                } else if isLastDay {
+                    name = "End"
+                } else {
+                    name = "Day \(day.dayNumber)"
+                }
+
+                let waypoint = RouteWaypoint(
+                    coordinate: coord,
+                    name: name,
+                    type: type,
+                    elevationMeters: day.endElevationMeters,
+                    dayNumber: day.dayNumber,
+                    date: day.date,
+                    notes: day.guideNotes.isEmpty ? nil : day.guideNotes,
+                    sourceId: day.id
+                )
+                waypoints.append(waypoint)
+            }
+        }
+
+        return waypoints
+    }
+
+    /// Extract waypoints from resupply points
+    static func extractWaypoints(from resupplyPoints: [ResupplyPoint]) -> [RouteWaypoint] {
+        resupplyPoints.compactMap { point in
+            guard let coord = point.coordinate else { return nil }
+
+            return RouteWaypoint(
+                coordinate: coord,
+                name: point.name.isEmpty ? "Resupply" : point.name,
+                type: .resupply,
+                elevationMeters: point.elevationMeters,
+                dayNumber: point.dayNumber,
+                date: point.expectedArrivalDate,
+                notes: point.servicesString.isEmpty ? nil : point.servicesString,
+                sourceId: point.id
+            )
+        }
+    }
+
+    /// Extract all waypoints from an expedition
+    static func extractWaypoints(from expedition: Expedition) -> [RouteWaypoint] {
+        var waypoints: [RouteWaypoint] = []
+
+        // Get waypoints from itinerary
+        if let days = expedition.itinerary {
+            waypoints.append(contentsOf: extractWaypoints(from: days))
+        }
+
+        // Get waypoints from resupply points
+        if let resupply = expedition.resupplyPoints {
+            waypoints.append(contentsOf: extractWaypoints(from: resupply))
+        }
+
+        // Sort by day number, then by type
+        return waypoints.sorted { lhs, rhs in
+            if let lDay = lhs.dayNumber, let rDay = rhs.dayNumber {
+                if lDay != rDay {
+                    return lDay < rDay
+                }
+            } else if lhs.dayNumber != nil {
+                return true
+            } else if rhs.dayNumber != nil {
+                return false
+            }
+            return lhs.type.sortOrder < rhs.type.sortOrder
+        }
+    }
+
+    // MARK: - Route Building
+
+    /// Build route coordinates from itinerary days
+    static func buildRoute(from days: [ItineraryDay]) -> [CLLocationCoordinate2D] {
+        var coordinates: [CLLocationCoordinate2D] = []
+        let sortedDays = days.sorted { $0.dayNumber < $1.dayNumber }
+
+        for day in sortedDays {
+            if let start = day.startCoordinate {
+                // Only add start if different from last coordinate
+                if let last = coordinates.last {
+                    if !coordinatesEqual(last, start) {
+                        coordinates.append(start)
+                    }
+                } else {
+                    coordinates.append(start)
+                }
+            }
+
+            if let end = day.endCoordinate {
+                // Only add end if different from last coordinate
+                if let last = coordinates.last {
+                    if !coordinatesEqual(last, end) {
+                        coordinates.append(end)
+                    }
+                } else {
+                    coordinates.append(end)
+                }
+            }
+        }
+
+        return coordinates
+    }
+
+    /// Check if two coordinates are approximately equal
+    private static func coordinatesEqual(
+        _ lhs: CLLocationCoordinate2D,
+        _ rhs: CLLocationCoordinate2D,
+        tolerance: Double = 0.0001
+    ) -> Bool {
+        abs(lhs.latitude - rhs.latitude) < tolerance &&
+        abs(lhs.longitude - rhs.longitude) < tolerance
+    }
+
+    // MARK: - Statistics
+
+    struct RouteStatistics {
+        let totalDistanceMeters: Double
+        let waypointCount: Int
+        let campsiteCount: Int
+        let resupplyCount: Int
+        let summitCount: Int
+        let highestElevationMeters: Double?
+        let lowestElevationMeters: Double?
+    }
+
+    /// Calculate route statistics
+    static func statistics(waypoints: [RouteWaypoint], route: [CLLocationCoordinate2D]) -> RouteStatistics {
+        let totalDistance = DistanceService.totalDistance(along: route)
+
+        let elevations = waypoints.compactMap { $0.elevationMeters }
+        let highest = elevations.max()
+        let lowest = elevations.min()
+
+        return RouteStatistics(
+            totalDistanceMeters: totalDistance,
+            waypointCount: waypoints.count,
+            campsiteCount: waypoints.filter { $0.type == .campsite }.count,
+            resupplyCount: waypoints.filter { $0.type == .resupply }.count,
+            summitCount: waypoints.filter { $0.type == .summit }.count,
+            highestElevationMeters: highest,
+            lowestElevationMeters: lowest
+        )
+    }
+
+    // MARK: - Filtering
+
+    /// Filter waypoints by type
+    static func filter(waypoints: [RouteWaypoint], by types: Set<WaypointType>) -> [RouteWaypoint] {
+        guard !types.isEmpty else { return waypoints }
+        return waypoints.filter { types.contains($0.type) }
+    }
+
+    /// Filter waypoints by day range
+    static func filter(
+        waypoints: [RouteWaypoint],
+        fromDay: Int?,
+        toDay: Int?
+    ) -> [RouteWaypoint] {
+        waypoints.filter { waypoint in
+            guard let day = waypoint.dayNumber else { return true }
+
+            if let from = fromDay, day < from {
+                return false
+            }
+            if let to = toDay, day > to {
+                return false
+            }
+            return true
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Services/ShelterService.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Services/ShelterService.swift
@@ -1,0 +1,276 @@
+import Foundation
+import CoreLocation
+
+/// Service for managing shelter cabin data
+struct ShelterService {
+    // MARK: - Shelter Cabin Model
+
+    struct ShelterCabin: Identifiable, Hashable {
+        let id: UUID
+        let name: String
+        let coordinate: CLLocationCoordinate2D
+        let elevationMeters: Double?
+        let capacity: Int?
+        let amenities: [Amenity]
+        let notes: String?
+        let region: Region
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            coordinate: CLLocationCoordinate2D,
+            elevationMeters: Double? = nil,
+            capacity: Int? = nil,
+            amenities: [Amenity] = [],
+            notes: String? = nil,
+            region: Region = .alaska
+        ) {
+            self.id = id
+            self.name = name
+            self.coordinate = coordinate
+            self.elevationMeters = elevationMeters
+            self.capacity = capacity
+            self.amenities = amenities
+            self.notes = notes
+            self.region = region
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(id)
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.id == rhs.id
+        }
+    }
+
+    enum Amenity: String, CaseIterable {
+        case woodStove = "Wood Stove"
+        case sleepingPlatform = "Sleeping Platform"
+        case firewood = "Firewood"
+        case outhouse = "Outhouse"
+        case water = "Water Source"
+        case firstAid = "First Aid Kit"
+        case emergencySupplies = "Emergency Supplies"
+        case helipad = "Helipad"
+
+        var icon: String {
+            switch self {
+            case .woodStove: return "flame.fill"
+            case .sleepingPlatform: return "bed.double.fill"
+            case .firewood: return "tree.fill"
+            case .outhouse: return "toilet.fill"
+            case .water: return "drop.fill"
+            case .firstAid: return "cross.case.fill"
+            case .emergencySupplies: return "bag.fill"
+            case .helipad: return "airplane"
+            }
+        }
+    }
+
+    enum Region: String, CaseIterable {
+        case alaska = "Alaska"
+        case yukon = "Yukon"
+        case brooksRange = "Brooks Range"
+        case denali = "Denali Area"
+
+        var description: String {
+            switch self {
+            case .alaska: return "General Alaska"
+            case .yukon: return "Yukon Territory"
+            case .brooksRange: return "Brooks Range, Alaska"
+            case .denali: return "Denali National Park Area"
+            }
+        }
+    }
+
+    // MARK: - Sample Alaska/Yukon Shelter Data
+
+    /// Sample shelter cabins for Alaska and Yukon expeditions
+    /// Based on typical backcountry shelter locations in these regions
+    static let sampleShelters: [ShelterCabin] = [
+        // Brooks Range Shelters
+        ShelterCabin(
+            name: "Chandalar Shelf Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 67.8912, longitude: -148.4521),
+            elevationMeters: 1220,
+            capacity: 6,
+            amenities: [.woodStove, .sleepingPlatform, .firewood],
+            notes: "Emergency shelter on Chandalar River route. Maintained by BLM.",
+            region: .brooksRange
+        ),
+        ShelterCabin(
+            name: "Atigun Pass Shelter",
+            coordinate: CLLocationCoordinate2D(latitude: 68.1342, longitude: -149.4823),
+            elevationMeters: 1463,
+            capacity: 4,
+            amenities: [.woodStove, .emergencySupplies, .firstAid],
+            notes: "High pass emergency shelter. Often used as storm refuge.",
+            region: .brooksRange
+        ),
+        ShelterCabin(
+            name: "Galbraith Lake Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 68.4521, longitude: -149.5012),
+            elevationMeters: 823,
+            capacity: 8,
+            amenities: [.woodStove, .sleepingPlatform, .firewood, .outhouse, .water],
+            notes: "Popular staging point for Brooks Range expeditions.",
+            region: .brooksRange
+        ),
+        ShelterCabin(
+            name: "Anaktuvuk Pass Community Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 68.1433, longitude: -151.7350),
+            elevationMeters: 661,
+            capacity: 10,
+            amenities: [.woodStove, .sleepingPlatform, .water, .firstAid],
+            notes: "Located near village. Check with community before use.",
+            region: .brooksRange
+        ),
+
+        // Denali Area Shelters
+        ShelterCabin(
+            name: "Wonder Lake Ranger Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 63.4534, longitude: -150.8723),
+            elevationMeters: 610,
+            capacity: 4,
+            amenities: [.woodStove, .firstAid, .emergencySupplies],
+            notes: "Emergency use only. Contact Denali NPS.",
+            region: .denali
+        ),
+        ShelterCabin(
+            name: "Kantishna Roadhouse Shelter",
+            coordinate: CLLocationCoordinate2D(latitude: 63.5412, longitude: -150.9934),
+            elevationMeters: 530,
+            capacity: 6,
+            amenities: [.woodStove, .sleepingPlatform, .water, .outhouse],
+            notes: "Historic mining district shelter.",
+            region: .denali
+        ),
+
+        // General Alaska
+        ShelterCabin(
+            name: "Wiseman Creek Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 67.4123, longitude: -150.1023),
+            elevationMeters: 390,
+            capacity: 6,
+            amenities: [.woodStove, .sleepingPlatform, .firewood, .outhouse],
+            notes: "BLM public use cabin. Reservations required.",
+            region: .alaska
+        ),
+        ShelterCabin(
+            name: "Coldfoot Emergency Shelter",
+            coordinate: CLLocationCoordinate2D(latitude: 67.2521, longitude: -150.1834),
+            elevationMeters: 317,
+            capacity: 8,
+            amenities: [.woodStove, .sleepingPlatform, .firstAid, .emergencySupplies],
+            notes: "Near Coldfoot services. Good staging point.",
+            region: .alaska
+        ),
+
+        // Yukon
+        ShelterCabin(
+            name: "Tombstone Mountain Shelter",
+            coordinate: CLLocationCoordinate2D(latitude: 64.4512, longitude: -138.2341),
+            elevationMeters: 1100,
+            capacity: 6,
+            amenities: [.woodStove, .sleepingPlatform, .firewood],
+            notes: "Tombstone Territorial Park emergency shelter.",
+            region: .yukon
+        ),
+        ShelterCabin(
+            name: "Grizzly Lake Cabin",
+            coordinate: CLLocationCoordinate2D(latitude: 64.5234, longitude: -138.4521),
+            elevationMeters: 980,
+            capacity: 4,
+            amenities: [.woodStove, .sleepingPlatform, .water],
+            notes: "Remote backcountry cabin. Good bear country awareness needed.",
+            region: .yukon
+        ),
+        ShelterCabin(
+            name: "Divide Lake Shelter",
+            coordinate: CLLocationCoordinate2D(latitude: 64.3892, longitude: -138.3012),
+            elevationMeters: 1250,
+            capacity: 4,
+            amenities: [.woodStove, .emergencySupplies],
+            notes: "High elevation emergency shelter.",
+            region: .yukon
+        )
+    ]
+
+    // MARK: - Filtering
+
+    /// Get shelters by region
+    static func shelters(in region: Region) -> [ShelterCabin] {
+        sampleShelters.filter { $0.region == region }
+    }
+
+    /// Get shelters within a distance of a coordinate
+    static func shelters(
+        near coordinate: CLLocationCoordinate2D,
+        withinMeters distance: Double
+    ) -> [ShelterCabin] {
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        return sampleShelters.filter { shelter in
+            let shelterLocation = CLLocation(
+                latitude: shelter.coordinate.latitude,
+                longitude: shelter.coordinate.longitude
+            )
+            return location.distance(from: shelterLocation) <= distance
+        }
+    }
+
+    /// Get shelters along a route (within distance of any route point)
+    static func shelters(
+        alongRoute coordinates: [CLLocationCoordinate2D],
+        withinMeters distance: Double = 10000 // 10km default
+    ) -> [ShelterCabin] {
+        var nearShelters: Set<ShelterCabin> = []
+
+        for coord in coordinates {
+            let nearby = shelters(near: coord, withinMeters: distance)
+            nearShelters.formUnion(nearby)
+        }
+
+        return Array(nearShelters).sorted { $0.name < $1.name }
+    }
+
+    // MARK: - Conversion to RouteWaypoint
+
+    /// Convert a shelter to a RouteWaypoint for map display
+    static func toWaypoint(_ shelter: ShelterCabin) -> RouteWaypoint {
+        let amenityNotes = shelter.amenities.map { $0.rawValue }.joined(separator: ", ")
+        let notes = [shelter.notes, "Amenities: \(amenityNotes)"]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+
+        return RouteWaypoint(
+            id: shelter.id,
+            coordinate: shelter.coordinate,
+            name: shelter.name,
+            type: .shelter,
+            elevationMeters: shelter.elevationMeters,
+            dayNumber: nil,
+            date: nil,
+            notes: notes.isEmpty ? nil : notes,
+            sourceId: shelter.id
+        )
+    }
+
+    /// Convert all shelters to RouteWaypoints
+    static func allShelterWaypoints() -> [RouteWaypoint] {
+        sampleShelters.map { toWaypoint($0) }
+    }
+
+    /// Get shelter waypoints for a specific region
+    static func shelterWaypoints(in region: Region) -> [RouteWaypoint] {
+        shelters(in: region).map { toWaypoint($0) }
+    }
+
+    /// Get shelter waypoints along a route
+    static func shelterWaypoints(
+        alongRoute coordinates: [CLLocationCoordinate2D],
+        withinMeters distance: Double = 10000
+    ) -> [RouteWaypoint] {
+        shelters(alongRoute: coordinates, withinMeters: distance).map { toWaypoint($0) }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/ViewModels/RouteMapViewModel.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ViewModels/RouteMapViewModel.swift
@@ -1,0 +1,242 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import MapKit
+import OSLog
+
+private let logger = Logger(subsystem: "com.expedition.planner", category: "RouteMapViewModel")
+
+@Observable
+final class RouteMapViewModel {
+    // MARK: - Properties
+
+    private(set) var expedition: Expedition
+    private var modelContext: ModelContext
+
+    var selectedWaypoint: RouteWaypoint?
+    var showElevationOverlay: Bool = false
+    var selectedWaypointTypes: Set<WaypointType> = Set(WaypointType.allCases)
+    var showNearbyShelters: Bool = true
+
+    /// Location manager for tracking
+    let locationManager = LocationManager()
+
+    /// Whether to follow user location on map
+    var followUserLocation: Bool = false
+
+    /// Whether tracking mode is active
+    var isTrackingExpedition: Bool {
+        locationManager.isTracking
+    }
+
+    // MARK: - Initialization
+
+    init(expedition: Expedition, modelContext: ModelContext) {
+        self.expedition = expedition
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Computed Properties
+
+    var waypoints: [RouteWaypoint] {
+        var allWaypoints = RouteService.extractWaypoints(from: expedition)
+
+        // Add nearby shelter cabins if enabled
+        if showNearbyShelters && !routeCoordinates.isEmpty {
+            let shelterWaypoints = ShelterService.shelterWaypoints(
+                alongRoute: routeCoordinates,
+                withinMeters: 15000 // 15km from route
+            )
+            allWaypoints.append(contentsOf: shelterWaypoints)
+        }
+
+        return allWaypoints
+    }
+
+    var filteredWaypoints: [RouteWaypoint] {
+        RouteService.filter(waypoints: waypoints, by: selectedWaypointTypes)
+    }
+
+    var routeCoordinates: [CLLocationCoordinate2D] {
+        let days = expedition.itinerary ?? []
+        return RouteService.buildRoute(from: days)
+    }
+
+    var statistics: RouteService.RouteStatistics {
+        RouteService.statistics(waypoints: waypoints, route: routeCoordinates)
+    }
+
+    var hasRouteData: Bool {
+        !routeCoordinates.isEmpty || !waypoints.isEmpty
+    }
+
+    var boundingBox: DistanceService.BoundingBox? {
+        let coords = waypoints.map { $0.coordinate } + routeCoordinates
+        return DistanceService.boundingBox(for: coords)
+    }
+
+    var mapCameraPosition: MapCameraPosition {
+        guard let bbox = boundingBox else {
+            return .automatic
+        }
+
+        let center = bbox.center
+        let latSpan = max(bbox.latitudeSpan * 1.2, 0.01)
+        let lonSpan = max(bbox.longitudeSpan * 1.2, 0.01)
+
+        let region = MKCoordinateRegion(
+            center: center,
+            span: MKCoordinateSpan(latitudeDelta: latSpan, longitudeDelta: lonSpan)
+        )
+
+        return .region(region)
+    }
+
+    // MARK: - Elevation Chart Data
+
+    var elevationChartData: [ElevationService.ElevationPoint] {
+        let days = expedition.sortedItinerary
+        return ElevationService.chartData(from: days)
+    }
+
+    // MARK: - Formatting
+
+    var formattedTotalDistance: String {
+        DistanceService.formatDistance(statistics.totalDistanceMeters)
+    }
+
+    func formattedElevation(_ meters: Double?, unit: ElevationUnit) -> String {
+        ElevationService.formatElevation(meters, unit: unit)
+    }
+
+    // MARK: - Actions
+
+    func selectWaypoint(_ waypoint: RouteWaypoint) {
+        selectedWaypoint = waypoint
+        logger.info("Selected waypoint: \(waypoint.name)")
+    }
+
+    func clearSelection() {
+        selectedWaypoint = nil
+    }
+
+    func toggleWaypointTypeFilter(_ type: WaypointType) {
+        if selectedWaypointTypes.contains(type) {
+            selectedWaypointTypes.remove(type)
+        } else {
+            selectedWaypointTypes.insert(type)
+        }
+    }
+
+    func showAllWaypointTypes() {
+        selectedWaypointTypes = Set(WaypointType.allCases)
+    }
+
+    func toggleElevationOverlay() {
+        showElevationOverlay.toggle()
+    }
+
+    // MARK: - GPX Import
+
+    func importWaypoints(_ importedWaypoints: [RouteWaypoint]) {
+        guard let days = expedition.itinerary else {
+            logger.warning("No itinerary to import waypoints into")
+            return
+        }
+
+        // For now, log the imported waypoints
+        // Full implementation would match imported waypoints to days
+        logger.info("Imported \(importedWaypoints.count) waypoints")
+
+        // Update coordinates on matching days by name
+        for waypoint in importedWaypoints {
+            for day in days {
+                if day.startLocation.lowercased() == waypoint.name.lowercased() {
+                    day.startLatitude = waypoint.coordinate.latitude
+                    day.startLongitude = waypoint.coordinate.longitude
+                    if let elevation = waypoint.elevationMeters {
+                        day.startElevationMeters = elevation
+                    }
+                }
+
+                if day.endLocation.lowercased() == waypoint.name.lowercased() {
+                    day.endLatitude = waypoint.coordinate.latitude
+                    day.endLongitude = waypoint.coordinate.longitude
+                    if let elevation = waypoint.elevationMeters {
+                        day.endElevationMeters = elevation
+                    }
+                }
+            }
+        }
+
+        save()
+    }
+
+    // MARK: - Location Tracking
+
+    /// Start tracking expedition progress
+    func startTracking() {
+        locationManager.startTracking()
+        followUserLocation = true
+        logger.info("Started expedition tracking")
+    }
+
+    /// Stop tracking and optionally save track
+    func stopTracking(saveTrack: Bool = true) {
+        let track = locationManager.stopTracking()
+        followUserLocation = false
+
+        if saveTrack && !track.isEmpty {
+            logger.info("Stopped tracking with \(track.count) points")
+            // Track can be exported or saved as needed
+        }
+    }
+
+    /// Get user's recorded track as coordinates
+    var userTrackCoordinates: [CLLocationCoordinate2D] {
+        locationManager.trackCoordinates
+    }
+
+    /// Distance traveled in current tracking session
+    var formattedDistanceTraveled: String {
+        DistanceService.formatDistance(locationManager.distanceTraveled)
+    }
+
+    /// Distance to next waypoint from current location
+    func distanceToNextWaypoint() -> String? {
+        guard let location = locationManager.currentLocation else { return nil }
+
+        // Find the next waypoint (closest one ahead)
+        // For now, just use all waypoints - a more sophisticated implementation
+        // would track which waypoints have been passed
+        let remainingWaypoints = waypoints
+
+        guard let nearest = remainingWaypoints.min(by: {
+            location.distance(from: CLLocation(
+                latitude: $0.coordinate.latitude,
+                longitude: $0.coordinate.longitude
+            )) < location.distance(from: CLLocation(
+                latitude: $1.coordinate.latitude,
+                longitude: $1.coordinate.longitude
+            ))
+        }) else { return nil }
+
+        let distance = location.distance(from: CLLocation(
+            latitude: nearest.coordinate.latitude,
+            longitude: nearest.coordinate.longitude
+        ))
+
+        return "\(DistanceService.formatDistance(distance)) to \(nearest.name)"
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        do {
+            try modelContext.save()
+            expedition.updatedAt = Date()
+        } catch {
+            logger.error("Failed to save route changes: \(error.localizedDescription)")
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
@@ -36,6 +36,15 @@ struct ExpeditionDetailView: View {
                         detail: "\((expedition.itinerary ?? []).count) days"
                     )
                 }
+
+                NavigationLink(value: ExpeditionSection.routeMap) {
+                    SectionRow(
+                        title: "Route Map",
+                        icon: "map",
+                        color: .cyan,
+                        detail: routeMapDetail
+                    )
+                }
             }
 
             // Logistics Section
@@ -146,6 +155,18 @@ struct ExpeditionDetailView: View {
         return formatter.string(from: NSDecimalNumber(decimal: expedition.totalBudget)) ?? "$0"
     }
 
+    private var routeMapDetail: String {
+        let waypoints = RouteService.extractWaypoints(from: expedition)
+        let waypointCount = waypoints.count
+        if waypointCount == 0 {
+            return "No waypoints"
+        } else if waypointCount == 1 {
+            return "1 waypoint"
+        } else {
+            return "\(waypointCount) waypoints"
+        }
+    }
+
     @ViewBuilder
     private func sectionView(for section: ExpeditionSection) -> some View {
         switch section {
@@ -153,6 +174,8 @@ struct ExpeditionDetailView: View {
             ExpeditionOverviewView(expedition: expedition)
         case .itinerary:
             ItineraryView(expedition: expedition)
+        case .routeMap:
+            RouteMapView(expedition: expedition)
         case .participants:
             ParticipantsPlaceholderView(expedition: expedition)
         case .contacts:
@@ -176,6 +199,7 @@ struct ExpeditionDetailView: View {
 enum ExpeditionSection: Hashable {
     case overview
     case itinerary
+    case routeMap
     case participants
     case contacts
     case resupply

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Itinerary/ItineraryView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Itinerary/ItineraryView.swift
@@ -15,6 +15,7 @@ struct ItineraryView: View {
     @State private var showingFilterSheet = false
     @State private var selectedDay: ItineraryDay?
     @State private var isEditMode = false
+    @State private var showingRouteMap = false
 
     var body: some View {
         Group {
@@ -45,9 +46,20 @@ struct ItineraryView: View {
 
             if let viewModel, viewModel.totalDays > 0 {
                 ToolbarItem(placement: .topBarLeading) {
-                    filterMenu(viewModel: viewModel)
+                    HStack(spacing: 16) {
+                        filterMenu(viewModel: viewModel)
+
+                        Button {
+                            showingRouteMap = true
+                        } label: {
+                            Image(systemName: "map")
+                        }
+                    }
                 }
             }
+        }
+        .navigationDestination(isPresented: $showingRouteMap) {
+            RouteMapView(expedition: expedition)
         }
         .sheet(isPresented: $showingAddSheet) {
             DayFormView(mode: .create(expedition: expedition), modelContext: modelContext)

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/GPXImportView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/GPXImportView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import CoreLocation
+
+struct GPXImportView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let onImport: ([RouteWaypoint]) -> Void
+
+    @State private var showingFilePicker = false
+    @State private var parseResult: GPXService.GPXParseResult?
+    @State private var errorMessage: String?
+    @State private var selectedWaypoints: Set<UUID> = []
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let result = parseResult {
+                    resultView(result: result)
+                } else {
+                    pickFileView
+                }
+            }
+            .navigationTitle("Import GPX")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                if parseResult != nil {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Import") {
+                            importSelected()
+                        }
+                        .disabled(selectedWaypoints.isEmpty)
+                    }
+                }
+            }
+            .fileImporter(
+                isPresented: $showingFilePicker,
+                allowedContentTypes: [UTType(filenameExtension: "gpx") ?? .xml],
+                allowsMultipleSelection: false
+            ) { result in
+                handleFileSelection(result)
+            }
+        }
+    }
+
+    // MARK: - Pick File View
+
+    private var pickFileView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "doc.badge.arrow.up")
+                .font(.system(size: 60))
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                Text("Import GPX File")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                Text("Select a GPX file to import waypoints and track data into your expedition.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Button {
+                showingFilePicker = true
+            } label: {
+                Label("Choose File", systemImage: "folder")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 48)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: - Result View
+
+    @ViewBuilder
+    private func resultView(result: GPXService.GPXParseResult) -> some View {
+        List {
+            // Summary Section
+            Section("File Summary") {
+                if let name = result.name {
+                    LabeledContent("Name", value: name)
+                }
+
+                LabeledContent("Waypoints", value: "\(result.waypoints.count)")
+                LabeledContent("Track Points", value: "\(result.trackPoints.count)")
+            }
+
+            // Waypoints Section
+            if !result.waypoints.isEmpty {
+                Section {
+                    ForEach(result.waypoints) { waypoint in
+                        waypointRow(waypoint: waypoint)
+                    }
+                } header: {
+                    HStack {
+                        Text("Waypoints")
+                        Spacer()
+                        Button(selectedWaypoints.count == result.waypoints.count ? "Deselect All" : "Select All") {
+                            if selectedWaypoints.count == result.waypoints.count {
+                                selectedWaypoints.removeAll()
+                            } else {
+                                selectedWaypoints = Set(result.waypoints.map { $0.id })
+                            }
+                        }
+                        .font(.caption)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // Select all waypoints by default
+            selectedWaypoints = Set(result.waypoints.map { $0.id })
+        }
+    }
+
+    private func waypointRow(waypoint: RouteWaypoint) -> some View {
+        Button {
+            toggleSelection(waypoint.id)
+        } label: {
+            HStack {
+                // Selection indicator
+                Image(systemName: selectedWaypoints.contains(waypoint.id) ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(selectedWaypoints.contains(waypoint.id) ? .blue : .secondary)
+
+                // Type icon
+                Image(systemName: waypoint.type.icon)
+                    .foregroundStyle(waypoint.type.color)
+                    .frame(width: 24)
+
+                // Name and coordinates
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(waypoint.name)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+
+                    Text(formatCoordinate(waypoint.coordinate))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Elevation if available
+                if let elevation = waypoint.elevationMeters {
+                    Text("\(Int(elevation))m")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Actions
+
+    private func handleFileSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else {
+                errorMessage = "No file selected"
+                return
+            }
+
+            // Start accessing security-scoped resource
+            guard url.startAccessingSecurityScopedResource() else {
+                errorMessage = "Cannot access file"
+                return
+            }
+
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            if let parsed = GPXService.parse(url: url) {
+                parseResult = parsed
+                errorMessage = nil
+            } else {
+                errorMessage = "Failed to parse GPX file. Please check the file format."
+            }
+
+        case .failure(let error):
+            errorMessage = "Error selecting file: \(error.localizedDescription)"
+        }
+    }
+
+    private func toggleSelection(_ id: UUID) {
+        if selectedWaypoints.contains(id) {
+            selectedWaypoints.remove(id)
+        } else {
+            selectedWaypoints.insert(id)
+        }
+    }
+
+    private func importSelected() {
+        guard let result = parseResult else { return }
+
+        let waypointsToImport = result.waypoints.filter { selectedWaypoints.contains($0.id) }
+        onImport(waypointsToImport)
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    private func formatCoordinate(_ coord: CLLocationCoordinate2D) -> String {
+        String(format: "%.4f, %.4f", coord.latitude, coord.longitude)
+    }
+}
+
+#Preview {
+    GPXImportView { _ in
+        // Preview action
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapOverlayView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapOverlayView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+struct RouteMapOverlayView: View {
+    @Bindable var viewModel: RouteMapViewModel
+    let elevationUnit: ElevationUnit
+
+    @State private var showingFilters = false
+    @State private var showingElevation = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Elevation chart overlay
+            if showingElevation {
+                elevationOverlay
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
+            // Stats bar and controls
+            controlBar
+        }
+        .animation(.easeInOut(duration: 0.2), value: showingElevation)
+    }
+
+    // MARK: - Control Bar
+
+    private var controlBar: some View {
+        HStack(spacing: 12) {
+            // Stats
+            statsContent
+
+            Spacer()
+
+            // Control buttons
+            controlButtons
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+    }
+
+    private var statsContent: some View {
+        HStack(spacing: 16) {
+            // Distance
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Distance")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(viewModel.formattedTotalDistance)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+
+            // Waypoints
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Waypoints")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("\(viewModel.statistics.waypointCount)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+
+            // Elevation range
+            if let high = viewModel.statistics.highestElevationMeters {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("High Point")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(viewModel.formattedElevation(high, unit: elevationUnit))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+            }
+        }
+    }
+
+    private var controlButtons: some View {
+        HStack(spacing: 8) {
+            // Filter button
+            Button {
+                showingFilters.toggle()
+            } label: {
+                Image(systemName: viewModel.selectedWaypointTypes.count < WaypointType.allCases.count
+                    ? "line.3.horizontal.decrease.circle.fill"
+                    : "line.3.horizontal.decrease.circle"
+                )
+                .font(.title2)
+            }
+            .popover(isPresented: $showingFilters) {
+                filterContent
+                    .presentationCompactAdaptation(.popover)
+            }
+
+            // Elevation toggle
+            Button {
+                showingElevation.toggle()
+            } label: {
+                let icon = showingElevation
+                ? "chart.line.uptrend.xyaxis.circle.fill"
+                : "chart.line.uptrend.xyaxis.circle"
+            Image(systemName: icon)
+                    .font(.title2)
+            }
+        }
+    }
+
+    // MARK: - Elevation Overlay
+
+    private var elevationOverlay: some View {
+        VStack(spacing: 0) {
+            // Handle
+            RoundedRectangle(cornerRadius: 2)
+                .fill(.secondary.opacity(0.5))
+                .frame(width: 36, height: 4)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            // Chart
+            ElevationChartCompactView(
+                data: viewModel.elevationChartData,
+                unit: elevationUnit
+            )
+            .frame(height: 120)
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+        .background(.regularMaterial)
+    }
+
+    // MARK: - Filter Content
+
+    private var filterContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Filter Waypoints")
+                    .font(.headline)
+                Spacer()
+                Button("Reset") {
+                    viewModel.showAllWaypointTypes()
+                }
+                .font(.caption)
+            }
+
+            Divider()
+
+            // Shelter cabin toggle
+            Toggle(isOn: $viewModel.showNearbyShelters) {
+                HStack {
+                    Image(systemName: "house.fill")
+                        .foregroundStyle(.teal)
+                    Text("Show Nearby Shelters")
+                }
+            }
+            .toggleStyle(.switch)
+
+            Divider()
+
+            ForEach(WaypointType.allCases, id: \.self) { type in
+                filterRow(for: type)
+            }
+        }
+        .padding()
+        .frame(width: 250)
+    }
+
+    private func filterRow(for type: WaypointType) -> some View {
+        Button {
+            viewModel.toggleWaypointTypeFilter(type)
+        } label: {
+            HStack {
+                Circle()
+                    .fill(type.color)
+                    .frame(width: 12, height: 12)
+
+                Text(type.rawValue)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                if viewModel.selectedWaypointTypes.contains(type) {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapSheets.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapSheets.swift
@@ -1,0 +1,368 @@
+import SwiftUI
+import UIKit
+import MapKit
+
+// MARK: - GPX Export View
+
+struct GPXExportView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let waypoints: [RouteWaypoint]
+    let routeCoordinates: [CLLocationCoordinate2D]
+    let expeditionName: String
+
+    @State private var includeTrack = true
+    @State private var includeWaypoints = true
+    @State private var isExporting = false
+    @State private var exportedURL: URL?
+    @State private var showingShareSheet = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Export Options") {
+                    Toggle("Include Waypoints", isOn: $includeWaypoints)
+                    Toggle("Include Track", isOn: $includeTrack)
+                }
+
+                Section("Summary") {
+                    LabeledContent("Waypoints", value: "\(waypoints.count)")
+                    LabeledContent("Track Points", value: "\(routeCoordinates.count)")
+                }
+
+                Section {
+                    Button {
+                        exportGPX()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isExporting {
+                                ProgressView()
+                            } else {
+                                Label("Export GPX File", systemImage: "square.and.arrow.up")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(!includeWaypoints && !includeTrack)
+                }
+            }
+            .navigationTitle("Export GPX")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .sheet(isPresented: $showingShareSheet) {
+                if let url = exportedURL {
+                    ShareSheet(items: [url])
+                }
+            }
+        }
+    }
+
+    private func exportGPX() {
+        isExporting = true
+
+        let waypointsToExport = includeWaypoints ? waypoints : []
+        let trackToExport = includeTrack ? routeCoordinates : []
+
+        let gpxString = GPXService.export(
+            waypoints: waypointsToExport,
+            trackCoordinates: trackToExport,
+            name: expeditionName
+        )
+
+        // Save to temp file
+        let fileName = "\(expeditionName.replacingOccurrences(of: " ", with: "_")).gpx"
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+
+        do {
+            try gpxString.write(to: tempURL, atomically: true, encoding: .utf8)
+            exportedURL = tempURL
+            showingShareSheet = true
+        } catch {
+            // Handle error silently for now
+        }
+
+        isExporting = false
+    }
+}
+
+// MARK: - Share Sheet
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+// MARK: - Tracking Control Sheet
+
+struct TrackingControlSheet: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    @Bindable var viewModel: RouteMapViewModel
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                // Status Section
+                Section("Location Status") {
+                    LabeledContent("Authorization") {
+                        Text(viewModel.locationManager.authorizationStatusDescription)
+                            .foregroundStyle(viewModel.locationManager.isAuthorized ? .green : .secondary)
+                    }
+
+                    if viewModel.locationManager.isDenied {
+                        Button("Open Settings") {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                    }
+                }
+
+                // Current Location Section
+                if let location = viewModel.locationManager.currentLocation {
+                    Section("Current Location") {
+                        LabeledContent("Latitude") {
+                            Text(String(format: "%.6f", location.coordinate.latitude))
+                                .font(.system(.body, design: .monospaced))
+                        }
+
+                        LabeledContent("Longitude") {
+                            Text(String(format: "%.6f", location.coordinate.longitude))
+                                .font(.system(.body, design: .monospaced))
+                        }
+
+                        LabeledContent("Altitude") {
+                            Text(String(format: "%.0f m", location.altitude))
+                        }
+
+                        LabeledContent("Accuracy") {
+                            Text(String(format: "%.0f m", location.horizontalAccuracy))
+                        }
+
+                        if let nextWaypoint = viewModel.distanceToNextWaypoint() {
+                            LabeledContent("Next Waypoint") {
+                                Text(nextWaypoint)
+                            }
+                        }
+                    }
+                }
+
+                // Tracking Section
+                Section("Expedition Tracking") {
+                    if viewModel.isTrackingExpedition {
+                        LabeledContent("Track Points") {
+                            Text("\(viewModel.userTrackCoordinates.count)")
+                        }
+
+                        LabeledContent("Distance Traveled") {
+                            Text(viewModel.formattedDistanceTraveled)
+                        }
+
+                        Button(role: .destructive) {
+                            viewModel.stopTracking()
+                            dismiss()
+                        } label: {
+                            Label("Stop Tracking", systemImage: "stop.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        Text("Track your expedition progress and record your route as you travel.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Button {
+                            viewModel.startTracking()
+                            dismiss()
+                        } label: {
+                            Label("Start Tracking", systemImage: "play.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .disabled(!viewModel.locationManager.isAuthorized)
+                    }
+                }
+
+                // Follow Location Toggle
+                Section {
+                    Toggle("Follow My Location", isOn: $viewModel.followUserLocation)
+                }
+            }
+            .navigationTitle("Location Tracking")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Offline Download Sheet
+
+struct OfflineDownloadSheet: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    @Bindable var viewModel: RouteMapViewModel
+    let expeditionName: String
+
+    @StateObject private var mapCache = MapCacheService.shared
+    @State private var selectedZoomLevel = 13
+    @State private var downloadError: String?
+
+    private let zoomLevels = [
+        (level: 10, description: "Overview (fastest)"),
+        (level: 12, description: "Regional"),
+        (level: 13, description: "Detailed (recommended)"),
+        (level: 15, description: "High Detail (large)")
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Region") {
+                    if let bbox = viewModel.boundingBox {
+                        LabeledContent("Area") {
+                            Text(String(format: "%.2f° × %.2f°", bbox.latitudeSpan, bbox.longitudeSpan))
+                        }
+
+                        LabeledContent("Center") {
+                            Text(String(format: "%.4f, %.4f", bbox.center.latitude, bbox.center.longitude))
+                                .font(.system(.body, design: .monospaced))
+                        }
+                    }
+
+                    LabeledContent("Waypoints") {
+                        Text("\(viewModel.waypoints.count)")
+                    }
+                }
+
+                Section("Download Options") {
+                    Picker("Detail Level", selection: $selectedZoomLevel) {
+                        ForEach(zoomLevels, id: \.level) { zoom in
+                            Text(zoom.description).tag(zoom.level)
+                        }
+                    }
+                }
+
+                Section {
+                    if let bbox = viewModel.boundingBox {
+                        let tileEstimate = estimateTileCount(bbox: bbox, maxZoom: selectedZoomLevel)
+                        LabeledContent("Estimated Tiles") {
+                            Text("\(tileEstimate)")
+                        }
+
+                        LabeledContent("Estimated Size") {
+                            Text(estimateSize(tileCount: tileEstimate))
+                        }
+                    }
+                } header: {
+                    Text("Estimate")
+                } footer: {
+                    Text("Actual size may vary. Tiles are sourced from OpenStreetMap.")
+                }
+
+                if let error = downloadError {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button {
+                        startDownload()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if mapCache.isDownloading {
+                                ProgressView()
+                                    .padding(.trailing, 8)
+                                Text("Downloading \(Int(mapCache.downloadProgress * 100))%")
+                            } else {
+                                Label("Download Map Region", systemImage: "arrow.down.circle.fill")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(viewModel.boundingBox == nil || mapCache.isDownloading)
+                }
+            }
+            .navigationTitle("Download Offline Map")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private func estimateTileCount(bbox: DistanceService.BoundingBox, maxZoom: Int) -> Int {
+        var count = 0
+        let minZoom = 10
+
+        for zoom in minZoom...maxZoom {
+            let tilesPerDegree = pow(2.0, Double(zoom)) / 360.0
+            let tilesX = Int(ceil(bbox.longitudeSpan * tilesPerDegree))
+            let tilesY = Int(ceil(bbox.latitudeSpan * tilesPerDegree))
+            count += tilesX * tilesY
+        }
+
+        return count
+    }
+
+    private func estimateSize(tileCount: Int) -> String {
+        // Average tile size is ~15KB
+        let bytes = Int64(tileCount * 15_000)
+        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func startDownload() {
+        guard let bbox = viewModel.boundingBox else { return }
+
+        downloadError = nil
+
+        Task {
+            do {
+                try await mapCache.downloadRegion(
+                    name: expeditionName,
+                    region: MKCoordinateRegion(
+                        center: bbox.center,
+                        span: MKCoordinateSpan(
+                            latitudeDelta: bbox.latitudeSpan * 1.2,
+                            longitudeDelta: bbox.longitudeSpan * 1.2
+                        )
+                    ),
+                    minZoom: 10,
+                    maxZoom: selectedZoomLevel
+                )
+                await MainActor.run {
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    downloadError = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/RouteMapView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+import SwiftData
+import MapKit
+
+enum MapStyleOption: String, CaseIterable {
+    case standard = "Standard"
+    case satellite = "Satellite"
+    case hybrid = "Hybrid"
+}
+
+struct RouteMapView: View {
+    @Environment(\.modelContext)
+    private var modelContext
+
+    @Bindable var expedition: Expedition
+
+    @AppStorage("elevationUnit")
+    private var elevationUnit: ElevationUnit = .meters
+
+    @State private var viewModel: RouteMapViewModel?
+    @State private var cameraPosition: MapCameraPosition = .automatic
+    @State private var showingWaypointDetail = false
+    @State private var showingGPXImport = false
+    @State private var showingGPXExport = false
+    @State private var selectedMapStyle: MapStyleOption = .standard
+    @State private var showingTrackingSheet = false
+    @State private var mapSelection: MapFeature?
+    @State private var showingOfflineDownload = false
+    @StateObject private var mapCache = MapCacheService.shared
+
+    private var mapStyle: MapStyle {
+        switch selectedMapStyle {
+        case .standard:
+            return .standard
+        case .satellite:
+            return .imagery
+        case .hybrid:
+            return .hybrid
+        }
+    }
+
+    var body: some View {
+        Group {
+            if let viewModel {
+                contentView(viewModel: viewModel)
+            } else {
+                ProgressView()
+            }
+        }
+        .navigationTitle("Route Map")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarLeading) {
+                if let viewModel {
+                    trackingButton(viewModel: viewModel)
+                }
+            }
+            ToolbarItemGroup(placement: .primaryAction) {
+                mapStyleMenu
+                gpxMenu
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = RouteMapViewModel(expedition: expedition, modelContext: modelContext)
+                if let vm = viewModel {
+                    cameraPosition = vm.mapCameraPosition
+                }
+            }
+        }
+        .sheet(isPresented: $showingWaypointDetail) {
+            if let viewModel, let waypoint = viewModel.selectedWaypoint {
+                WaypointDetailSheet(
+                    waypoint: waypoint,
+                    elevationUnit: elevationUnit
+                )
+            }
+        }
+        .sheet(isPresented: $showingGPXImport) {
+            GPXImportView { waypoints in
+                viewModel?.importWaypoints(waypoints)
+            }
+        }
+        .sheet(isPresented: $showingGPXExport) {
+            if let viewModel {
+                GPXExportView(
+                    waypoints: viewModel.waypoints,
+                    routeCoordinates: viewModel.routeCoordinates,
+                    expeditionName: expedition.name
+                )
+            }
+        }
+        .sheet(isPresented: $showingTrackingSheet) {
+            if let viewModel {
+                TrackingControlSheet(viewModel: viewModel)
+                    .presentationDetents([.medium])
+            }
+        }
+        .sheet(isPresented: $showingOfflineDownload) {
+            if let viewModel {
+                OfflineDownloadSheet(
+                    viewModel: viewModel,
+                    expeditionName: expedition.name
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contentView(viewModel: RouteMapViewModel) -> some View {
+        if viewModel.hasRouteData {
+            ZStack(alignment: .bottom) {
+                mapContent(viewModel: viewModel)
+
+                RouteMapOverlayView(
+                    viewModel: viewModel,
+                    elevationUnit: elevationUnit
+                )
+            }
+        } else {
+            emptyState
+        }
+    }
+
+    @ViewBuilder
+    private func mapContent(viewModel: RouteMapViewModel) -> some View {
+        Map(position: $cameraPosition) {
+            // Route polyline
+            if viewModel.routeCoordinates.count >= 2 {
+                MapPolyline(coordinates: viewModel.routeCoordinates)
+                    .stroke(.blue, lineWidth: 3)
+            }
+
+            // User's recorded track (shown in green)
+            if viewModel.userTrackCoordinates.count >= 2 {
+                MapPolyline(coordinates: viewModel.userTrackCoordinates)
+                    .stroke(.green, lineWidth: 4)
+            }
+
+            // Waypoint markers
+            ForEach(viewModel.filteredWaypoints) { waypoint in
+                Annotation(
+                    waypoint.name,
+                    coordinate: waypoint.coordinate,
+                    anchor: .bottom
+                ) {
+                    WaypointAnnotation(
+                        waypoint: waypoint,
+                        isSelected: viewModel.selectedWaypoint?.id == waypoint.id,
+                        onTap: {
+                            viewModel.selectWaypoint(waypoint)
+                            showingWaypointDetail = true
+                        }
+                    )
+                }
+            }
+
+            // User location
+            UserAnnotation()
+        }
+        .mapStyle(mapStyle)
+        .mapControls {
+            MapCompass()
+            MapScaleView()
+            MapUserLocationButton()
+        }
+        .onAppear {
+            // Request location updates when map appears
+            viewModel.locationManager.startUpdatingLocation()
+        }
+        .onChange(of: viewModel.followUserLocation) { _, follow in
+            if follow, let location = viewModel.locationManager.currentLocation {
+                cameraPosition = .camera(MapCamera(
+                    centerCoordinate: location.coordinate,
+                    distance: 1000
+                ))
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Route Data", systemImage: "map")
+        } description: {
+            Text("Add coordinates to your itinerary days to see your route on the map.")
+        } actions: {
+            Button {
+                showingGPXImport = true
+            } label: {
+                Label("Import GPX", systemImage: "square.and.arrow.down")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var mapStyleMenu: some View {
+        Menu {
+            Button {
+                selectedMapStyle = .standard
+            } label: {
+                Label("Standard", systemImage: selectedMapStyle == .standard ? "checkmark" : "")
+            }
+
+            Button {
+                selectedMapStyle = .satellite
+            } label: {
+                Label("Satellite", systemImage: selectedMapStyle == .satellite ? "checkmark" : "")
+            }
+
+            Button {
+                selectedMapStyle = .hybrid
+            } label: {
+                Label("Hybrid", systemImage: selectedMapStyle == .hybrid ? "checkmark" : "")
+            }
+        } label: {
+            Image(systemName: "map")
+        }
+    }
+
+    @ViewBuilder
+    private func trackingButton(viewModel: RouteMapViewModel) -> some View {
+        Button {
+            if viewModel.isTrackingExpedition {
+                showingTrackingSheet = true
+            } else {
+                if viewModel.locationManager.isAuthorized {
+                    showingTrackingSheet = true
+                } else {
+                    viewModel.locationManager.requestAuthorization()
+                }
+            }
+        } label: {
+            Image(systemName: viewModel.isTrackingExpedition
+                ? "location.fill"
+                : "location")
+            .foregroundStyle(viewModel.isTrackingExpedition ? .green : .primary)
+        }
+    }
+
+    private var gpxMenu: some View {
+        Menu {
+            Button {
+                showingGPXImport = true
+            } label: {
+                Label("Import GPX", systemImage: "square.and.arrow.down")
+            }
+
+            Button {
+                showingGPXExport = true
+            } label: {
+                Label("Export GPX", systemImage: "square.and.arrow.up")
+            }
+            .disabled(viewModel?.waypoints.isEmpty ?? true)
+
+            Divider()
+
+            Button {
+                showingOfflineDownload = true
+            } label: {
+                if mapCache.isDownloading {
+                    Label("Downloading...", systemImage: "arrow.down.circle")
+                } else {
+                    Label("Download for Offline", systemImage: "arrow.down.circle")
+                }
+            }
+            .disabled(viewModel?.boundingBox == nil || mapCache.isDownloading)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RouteMapView(expedition: Expedition(name: "Test Expedition"))
+    }
+    .modelContainer(for: Expedition.self, inMemory: true)
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/WaypointDetailSheet.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/WaypointDetailSheet.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import MapKit
+
+struct WaypointDetailSheet: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let waypoint: RouteWaypoint
+    let elevationUnit: ElevationUnit
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    // Header
+                    headerSection
+
+                    // Info Card
+                    infoCard
+
+                    // Map Preview
+                    mapPreview
+
+                    // Coordinates Card
+                    coordinatesCard
+                }
+                .padding()
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Waypoint")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(waypoint.type.color.opacity(0.15))
+                    .frame(width: 60, height: 60)
+
+                Image(systemName: waypoint.type.icon)
+                    .font(.title)
+                    .foregroundStyle(waypoint.type.color)
+            }
+
+            Text(waypoint.name)
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(waypoint.type.rawValue)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical)
+        .background(waypoint.type.color.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Info Card
+
+    private var infoCard: some View {
+        GroupBox("Details") {
+            VStack(spacing: 12) {
+                if let dayNumber = waypoint.dayNumber {
+                    LabeledContent("Day", value: "Day \(dayNumber)")
+                }
+
+                if let date = waypoint.date {
+                    LabeledContent("Date") {
+                        Text(date.formatted(date: .abbreviated, time: .omitted))
+                    }
+                }
+
+                if let elevation = waypoint.elevationMeters {
+                    LabeledContent("Elevation") {
+                        Text(ElevationService.formatElevation(elevation, unit: elevationUnit))
+                    }
+                }
+
+                if let notes = waypoint.notes, !notes.isEmpty {
+                    Divider()
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Notes")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(notes)
+                            .font(.body)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    // MARK: - Map Preview
+
+    private var mapPreview: some View {
+        GroupBox("Location") {
+            Map {
+                Marker(waypoint.name, coordinate: waypoint.coordinate)
+                    .tint(waypoint.type.color)
+            }
+            .frame(height: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    // MARK: - Coordinates Card
+
+    private var coordinatesCard: some View {
+        GroupBox("Coordinates") {
+            VStack(spacing: 8) {
+                LabeledContent("Latitude") {
+                    Text(formatCoordinate(waypoint.coordinate.latitude, isLatitude: true))
+                        .font(.system(.body, design: .monospaced))
+                }
+
+                LabeledContent("Longitude") {
+                    Text(formatCoordinate(waypoint.coordinate.longitude, isLatitude: false))
+                        .font(.system(.body, design: .monospaced))
+                }
+
+                Divider()
+
+                Button {
+                    openInMaps()
+                } label: {
+                    Label("Open in Maps", systemImage: "map")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatCoordinate(_ value: Double, isLatitude: Bool) -> String {
+        let direction: String
+        if isLatitude {
+            direction = value >= 0 ? "N" : "S"
+        } else {
+            direction = value >= 0 ? "E" : "W"
+        }
+
+        let absValue = abs(value)
+        let degrees = Int(absValue)
+        let minutes = Int((absValue - Double(degrees)) * 60)
+        let seconds = ((absValue - Double(degrees)) * 60 - Double(minutes)) * 60
+
+        return String(format: "%d° %d' %.1f\" %@", degrees, minutes, seconds, direction)
+    }
+
+    private func openInMaps() {
+        let placemark = MKPlacemark(coordinate: waypoint.coordinate)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = waypoint.name
+        mapItem.openInMaps(launchOptions: nil)
+    }
+}
+
+#Preview {
+    WaypointDetailSheet(
+        waypoint: RouteWaypoint(
+            coordinate: CLLocationCoordinate2D(latitude: 68.1234, longitude: -149.5678),
+            name: "Arctic Camp",
+            type: .campsite,
+            elevationMeters: 1250,
+            dayNumber: 5,
+            date: Date(),
+            notes: "Good water source nearby. Protected from wind.",
+            sourceId: UUID()
+        ),
+        elevationUnit: .meters
+    )
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Map/WaypointMarkerView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Map/WaypointMarkerView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+import MapKit
+
+struct WaypointMarkerView: View {
+    let waypoint: RouteWaypoint
+
+    var body: some View {
+        ZStack {
+            // Background circle
+            Circle()
+                .fill(waypoint.type.color)
+                .frame(width: 32, height: 32)
+
+            // Icon
+            Image(systemName: waypoint.type.icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+    }
+}
+
+struct WaypointAnnotation: View {
+    let waypoint: RouteWaypoint
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Marker
+            ZStack {
+                // Selection ring
+                if isSelected {
+                    Circle()
+                        .stroke(waypoint.type.color, lineWidth: 3)
+                        .frame(width: 44, height: 44)
+                }
+
+                // Marker content
+                Circle()
+                    .fill(waypoint.type.color)
+                    .frame(width: 36, height: 36)
+
+                Image(systemName: waypoint.type.icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+
+            // Pointer triangle
+            Triangle()
+                .fill(waypoint.type.color)
+                .frame(width: 12, height: 8)
+                .offset(y: -2)
+
+            // Label
+            if isSelected {
+                Text(waypoint.name)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.top, 4)
+            }
+        }
+        .onTapGesture {
+            onTap()
+        }
+    }
+}
+
+// MARK: - Triangle Shape
+
+struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Waypoint Type Badge
+
+struct WaypointTypeBadge: View {
+    let type: WaypointType
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 4) {
+                Image(systemName: type.icon)
+                    .font(.caption)
+                Text(type.rawValue)
+                    .font(.caption)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                isSelected ? type.color.opacity(0.2) : Color(.systemGray5),
+                in: Capsule()
+            )
+            .foregroundStyle(isSelected ? type.color : .secondary)
+            .overlay(
+                Capsule()
+                    .stroke(isSelected ? type.color : .clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Waypoint Type Legend
+
+struct WaypointTypeLegend: View {
+    let waypointCounts: [WaypointType: Int]
+
+    private var sortedTypes: [WaypointType] {
+        waypointCounts.keys.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(sortedTypes, id: \.self) { type in
+                if let count = waypointCounts[type], count > 0 {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(type.color)
+                            .frame(width: 12, height: 12)
+
+                        Text(type.rawValue)
+                            .font(.caption)
+
+                        Spacer()
+
+                        Text("\(count)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview("Marker") {
+    WaypointMarkerView(
+        waypoint: RouteWaypoint(
+            coordinate: .init(latitude: 0, longitude: 0),
+            name: "Test Camp",
+            type: .campsite,
+            sourceId: UUID()
+        )
+    )
+    .padding()
+}
+
+#Preview("Annotation") {
+    WaypointAnnotation(
+        waypoint: RouteWaypoint(
+            coordinate: .init(latitude: 0, longitude: 0),
+            name: "Summit Peak",
+            type: .summit,
+            sourceId: UUID()
+        ),
+        isSelected: true,
+        onTap: {}
+    )
+    .padding()
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Settings/SettingsView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Settings/SettingsView.swift
@@ -175,8 +175,10 @@ struct SettingsView: View {
 // MARK: - Data Management View
 
 struct DataManagementView: View {
+    @StateObject private var mapCache = MapCacheService.shared
     @State private var showingExportSheet = false
     @State private var showingClearConfirmation = false
+    @State private var showingDownloadSheet = false
 
     var body: some View {
         List {
@@ -198,26 +200,70 @@ struct DataManagementView: View {
                 Text("Export your expedition data for backup or transfer.")
             }
 
+            // Offline Maps Section
             Section {
+                LabeledContent("Cache Size", value: mapCache.formattedCacheSize)
+
+                if mapCache.isDownloading {
+                    HStack {
+                        Text("Downloading...")
+                        Spacer()
+                        ProgressView(value: mapCache.downloadProgress)
+                            .frame(width: 100)
+                    }
+                }
+
+                ForEach(mapCache.cachedRegions) { region in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(region.name)
+                            .font(.body)
+                        HStack {
+                            Text("\(region.tileCount) tiles")
+                            Text("•")
+                            Text(region.formattedSize)
+                            Text("•")
+                            Text("Zoom \(region.minZoom)-\(region.maxZoom)")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            mapCache.deleteRegion(region)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+
                 Button(role: .destructive) {
                     showingClearConfirmation = true
                 } label: {
-                    Label("Clear Cache", systemImage: "trash")
+                    Label("Clear All Map Cache", systemImage: "trash")
                 }
+                .disabled(mapCache.cachedRegions.isEmpty)
             } header: {
-                Text("Cache")
+                Text("Offline Maps")
             } footer: {
-                Text("Clearing the cache removes temporary files and downloaded maps.")
+                Text(offlineMapsFooter)
             }
         }
         .navigationTitle("Data Management")
         .confirmationDialog("Clear Cache?", isPresented: $showingClearConfirmation) {
             Button("Clear Cache", role: .destructive) {
-                // Clear cache action
+                mapCache.clearCache()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will remove temporary files and downloaded offline maps.")
+            Text("This will remove all downloaded offline map tiles.")
+        }
+    }
+
+    private var offlineMapsFooter: String {
+        if mapCache.cachedRegions.isEmpty {
+            return "Download map regions from the Route Map view for offline use."
+        } else {
+            return "Swipe left on a region to delete it."
         }
     }
 }

--- a/ExpeditionPlanner/ExpeditionPlannerTests/DistanceServiceTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/DistanceServiceTests.swift
@@ -1,0 +1,266 @@
+import XCTest
+import CoreLocation
+@testable import ExpeditionPlanner
+
+final class DistanceServiceTests: XCTestCase {
+
+    // MARK: - Distance Calculation Tests
+
+    func testDistanceBetweenSamePoint() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
+        let distance = DistanceService.distance(from: coord, to: coord)
+        XCTAssertEqual(distance, 0, accuracy: 0.001)
+    }
+
+    func testDistanceNYCToLA() {
+        // New York City
+        let nyc = CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)
+        // Los Angeles
+        let la = CLLocationCoordinate2D(latitude: 34.0522, longitude: -118.2437)
+
+        let distance = DistanceService.distance(from: nyc, to: la)
+
+        // Expected ~3940 km
+        let expectedKm = 3940.0
+        let actualKm = distance / 1000.0
+        XCTAssertEqual(actualKm, expectedKm, accuracy: 50) // Within 50km
+    }
+
+    func testDistanceShortRange() {
+        // Two points ~1km apart
+        let point1 = CLLocationCoordinate2D(latitude: 40.0000, longitude: -74.0000)
+        let point2 = CLLocationCoordinate2D(latitude: 40.0090, longitude: -74.0000)
+
+        let distance = DistanceService.distance(from: point1, to: point2)
+
+        // ~1000 meters
+        XCTAssertEqual(distance, 1000, accuracy: 10)
+    }
+
+    // MARK: - Total Distance Tests
+
+    func testTotalDistanceEmptyArray() {
+        let total = DistanceService.totalDistance(along: [])
+        XCTAssertEqual(total, 0)
+    }
+
+    func testTotalDistanceSinglePoint() {
+        let coords = [CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)]
+        let total = DistanceService.totalDistance(along: coords)
+        XCTAssertEqual(total, 0)
+    }
+
+    func testTotalDistanceMultiplePoints() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 40.0000, longitude: -74.0000),
+            CLLocationCoordinate2D(latitude: 40.0090, longitude: -74.0000), // ~1km
+            CLLocationCoordinate2D(latitude: 40.0180, longitude: -74.0000)  // ~1km more
+        ]
+
+        let total = DistanceService.totalDistance(along: coords)
+
+        // Should be ~2000m
+        XCTAssertEqual(total, 2000, accuracy: 20)
+    }
+
+    // MARK: - Bearing Tests
+
+    func testBearingNorth() {
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 41.0, longitude: -74.0)
+
+        let bearing = DistanceService.bearing(from: start, to: end)
+
+        // Should be approximately 0 (north)
+        XCTAssertEqual(bearing, 0, accuracy: 1)
+    }
+
+    func testBearingEast() {
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 40.0, longitude: -73.0)
+
+        let bearing = DistanceService.bearing(from: start, to: end)
+
+        // Should be approximately 90 (east)
+        XCTAssertEqual(bearing, 90, accuracy: 2)
+    }
+
+    func testBearingSouth() {
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 39.0, longitude: -74.0)
+
+        let bearing = DistanceService.bearing(from: start, to: end)
+
+        // Should be approximately 180 (south)
+        XCTAssertEqual(bearing, 180, accuracy: 1)
+    }
+
+    func testBearingWest() {
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 40.0, longitude: -75.0)
+
+        let bearing = DistanceService.bearing(from: start, to: end)
+
+        // Should be approximately 270 (west)
+        XCTAssertEqual(bearing, 270, accuracy: 2)
+    }
+
+    // MARK: - Cardinal Direction Tests
+
+    func testCardinalDirectionNorth() {
+        let direction = DistanceService.cardinalDirection(from: 0)
+        XCTAssertEqual(direction, "N")
+    }
+
+    func testCardinalDirectionEast() {
+        let direction = DistanceService.cardinalDirection(from: 90)
+        XCTAssertEqual(direction, "E")
+    }
+
+    func testCardinalDirectionSouth() {
+        let direction = DistanceService.cardinalDirection(from: 180)
+        XCTAssertEqual(direction, "S")
+    }
+
+    func testCardinalDirectionWest() {
+        let direction = DistanceService.cardinalDirection(from: 270)
+        XCTAssertEqual(direction, "W")
+    }
+
+    func testCardinalDirectionNortheast() {
+        let direction = DistanceService.cardinalDirection(from: 45)
+        XCTAssertEqual(direction, "NE")
+    }
+
+    // MARK: - Unit Conversion Tests
+
+    func testMetersToKilometers() {
+        let km = DistanceService.metersToKilometers(5000)
+        XCTAssertEqual(km, 5.0)
+    }
+
+    func testMetersToMiles() {
+        let miles = DistanceService.metersToMiles(1609.344)
+        XCTAssertEqual(miles, 1.0, accuracy: 0.001)
+    }
+
+    func testKilometersToMeters() {
+        let meters = DistanceService.kilometersToMeters(5)
+        XCTAssertEqual(meters, 5000)
+    }
+
+    func testMilesToMeters() {
+        let meters = DistanceService.milesToMeters(1)
+        XCTAssertEqual(meters, 1609.344, accuracy: 0.001)
+    }
+
+    // MARK: - Formatting Tests
+
+    func testFormatDistanceMetric() {
+        let short = DistanceService.formatDistance(500)
+        XCTAssertEqual(short, "500 m")
+
+        let long = DistanceService.formatDistance(5000)
+        XCTAssertEqual(long, "5.0 km")
+    }
+
+    func testFormatDistanceImperial() {
+        let short = DistanceService.formatDistance(100, useMetric: false)
+        XCTAssertTrue(short.contains("ft"))
+
+        let long = DistanceService.formatDistance(5000, useMetric: false)
+        XCTAssertTrue(long.contains("mi"))
+    }
+
+    func testFormatBearing() {
+        let formatted = DistanceService.formatBearing(45)
+        XCTAssertEqual(formatted, "45° NE")
+    }
+
+    // MARK: - Bounding Box Tests
+
+    func testBoundingBoxEmpty() {
+        let bbox = DistanceService.boundingBox(for: [])
+        XCTAssertNil(bbox)
+    }
+
+    func testBoundingBoxSinglePoint() {
+        let coords = [CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)]
+        let bbox = DistanceService.boundingBox(for: coords)
+
+        XCTAssertNotNil(bbox)
+        XCTAssertEqual(bbox?.minLatitude, 40.0)
+        XCTAssertEqual(bbox?.maxLatitude, 40.0)
+        XCTAssertEqual(bbox?.minLongitude, -74.0)
+        XCTAssertEqual(bbox?.maxLongitude, -74.0)
+    }
+
+    func testBoundingBoxMultiplePoints() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+            CLLocationCoordinate2D(latitude: 39.0, longitude: -75.0)
+        ]
+        let bbox = DistanceService.boundingBox(for: coords)
+
+        XCTAssertNotNil(bbox)
+        XCTAssertEqual(bbox?.minLatitude, 39.0)
+        XCTAssertEqual(bbox?.maxLatitude, 41.0)
+        XCTAssertEqual(bbox?.minLongitude, -75.0)
+        XCTAssertEqual(bbox?.maxLongitude, -73.0)
+    }
+
+    func testBoundingBoxCenter() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            CLLocationCoordinate2D(latitude: 42.0, longitude: -72.0)
+        ]
+        let bbox = DistanceService.boundingBox(for: coords)
+
+        XCTAssertEqual(bbox?.center.latitude, 41.0)
+        XCTAssertEqual(bbox?.center.longitude, -73.0)
+    }
+
+    func testBoundingBoxSpan() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            CLLocationCoordinate2D(latitude: 42.0, longitude: -72.0)
+        ]
+        let bbox = DistanceService.boundingBox(for: coords)
+
+        XCTAssertEqual(bbox?.latitudeSpan, 2.0)
+        XCTAssertEqual(bbox?.longitudeSpan, 2.0)
+    }
+
+    // MARK: - Distance to Segment Tests
+
+    func testDistanceToSegmentOnLine() {
+        let point = CLLocationCoordinate2D(latitude: 40.5, longitude: -74.0)
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 41.0, longitude: -74.0)
+
+        let distance = DistanceService.distanceToSegment(
+            point: point,
+            segmentStart: start,
+            segmentEnd: end
+        )
+
+        // Point is on the line, distance should be very small
+        XCTAssertEqual(distance, 0, accuracy: 1)
+    }
+
+    func testDistanceToSegmentOffLine() {
+        let point = CLLocationCoordinate2D(latitude: 40.5, longitude: -73.0)
+        let start = CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0)
+        let end = CLLocationCoordinate2D(latitude: 41.0, longitude: -74.0)
+
+        let distance = DistanceService.distanceToSegment(
+            point: point,
+            segmentStart: start,
+            segmentEnd: end
+        )
+
+        // Point is 1 degree longitude away
+        XCTAssertGreaterThan(distance, 50000) // Should be > 50km
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlannerTests/GPXServiceTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/GPXServiceTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+import CoreLocation
+@testable import ExpeditionPlanner
+
+final class GPXServiceTests: XCTestCase {
+
+    // MARK: - Export Tests
+
+    func testExportEmptyData() {
+        let gpx = GPXService.export(
+            waypoints: [],
+            trackCoordinates: [],
+            name: nil,
+            description: nil
+        )
+
+        XCTAssertTrue(gpx.contains("<?xml"))
+        XCTAssertTrue(gpx.contains("<gpx"))
+        XCTAssertTrue(gpx.contains("</gpx>"))
+        XCTAssertFalse(gpx.contains("<wpt"))
+        XCTAssertFalse(gpx.contains("<trk"))
+    }
+
+    func testExportWithMetadata() {
+        let gpx = GPXService.export(
+            waypoints: [],
+            trackCoordinates: [],
+            name: "Test Expedition",
+            description: "A test expedition"
+        )
+
+        XCTAssertTrue(gpx.contains("<metadata>"))
+        XCTAssertTrue(gpx.contains("<name>Test Expedition</name>"))
+        XCTAssertTrue(gpx.contains("<desc>A test expedition</desc>"))
+        XCTAssertTrue(gpx.contains("<time>"))
+    }
+
+    func testExportWithWaypoints() {
+        let waypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Start Point",
+                type: .startPoint,
+                elevationMeters: 1000,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+                name: "Camp 1",
+                type: .campsite,
+                elevationMeters: 2000,
+                notes: "Good water source",
+                sourceId: UUID()
+            )
+        ]
+
+        let gpx = GPXService.export(
+            waypoints: waypoints,
+            trackCoordinates: [],
+            name: "Test"
+        )
+
+        XCTAssertTrue(gpx.contains("<wpt lat=\"40.0\" lon=\"-74.0\">"))
+        XCTAssertTrue(gpx.contains("<name>Start Point</name>"))
+        XCTAssertTrue(gpx.contains("<ele>1000.0</ele>"))
+        XCTAssertTrue(gpx.contains("<type>Start Point</type>"))
+
+        XCTAssertTrue(gpx.contains("<wpt lat=\"41.0\" lon=\"-73.0\">"))
+        XCTAssertTrue(gpx.contains("<name>Camp 1</name>"))
+        XCTAssertTrue(gpx.contains("<desc>Good water source</desc>"))
+    }
+
+    func testExportWithTrack() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            CLLocationCoordinate2D(latitude: 40.5, longitude: -73.5),
+            CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0)
+        ]
+
+        let gpx = GPXService.export(
+            waypoints: [],
+            trackCoordinates: coordinates,
+            name: "Test Route"
+        )
+
+        XCTAssertTrue(gpx.contains("<trk>"))
+        XCTAssertTrue(gpx.contains("<name>Test Route Track</name>"))
+        XCTAssertTrue(gpx.contains("<trkseg>"))
+        XCTAssertTrue(gpx.contains("<trkpt lat=\"40.0\" lon=\"-74.0\"/>"))
+        XCTAssertTrue(gpx.contains("<trkpt lat=\"40.5\" lon=\"-73.5\"/>"))
+        XCTAssertTrue(gpx.contains("<trkpt lat=\"41.0\" lon=\"-73.0\"/>"))
+        XCTAssertTrue(gpx.contains("</trkseg>"))
+        XCTAssertTrue(gpx.contains("</trk>"))
+    }
+
+    func testExportEscapesXMLCharacters() {
+        let waypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Camp <Test> & \"Special\"",
+                type: .campsite,
+                notes: "Use caution 'here'",
+                sourceId: UUID()
+            )
+        ]
+
+        let gpx = GPXService.export(
+            waypoints: waypoints,
+            trackCoordinates: [],
+            name: nil
+        )
+
+        XCTAssertTrue(gpx.contains("&lt;Test&gt;"))
+        XCTAssertTrue(gpx.contains("&amp;"))
+        XCTAssertTrue(gpx.contains("&quot;Special&quot;"))
+        XCTAssertTrue(gpx.contains("&apos;here&apos;"))
+    }
+
+    // MARK: - Parse Tests
+
+    func testParseValidGPX() {
+        let gpxData = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Test">
+            <metadata>
+                <name>Test Route</name>
+                <desc>A test route</desc>
+            </metadata>
+            <wpt lat="40.0" lon="-74.0">
+                <ele>1000</ele>
+                <name>Start</name>
+                <type>Start Point</type>
+            </wpt>
+            <wpt lat="41.0" lon="-73.0">
+                <ele>2000</ele>
+                <name>End</name>
+                <type>End Point</type>
+            </wpt>
+            <trk>
+                <name>Track</name>
+                <trkseg>
+                    <trkpt lat="40.0" lon="-74.0"/>
+                    <trkpt lat="40.5" lon="-73.5"/>
+                    <trkpt lat="41.0" lon="-73.0"/>
+                </trkseg>
+            </trk>
+        </gpx>
+        """.data(using: .utf8)!
+
+        let result = GPXService.parse(data: gpxData)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.name, "Test Route")
+        XCTAssertEqual(result?.description, "A test route")
+        XCTAssertEqual(result?.waypoints.count, 2)
+        XCTAssertEqual(result?.trackPoints.count, 3)
+
+        let startWaypoint = result?.waypoints.first
+        XCTAssertEqual(startWaypoint?.name, "Start")
+        XCTAssertEqual(startWaypoint?.coordinate.latitude, 40.0)
+        XCTAssertEqual(startWaypoint?.coordinate.longitude, -74.0)
+        XCTAssertEqual(startWaypoint?.elevationMeters, 1000)
+        XCTAssertEqual(startWaypoint?.type, .startPoint)
+    }
+
+    func testParseMinimalGPX() {
+        let gpxData = """
+        <?xml version="1.0"?>
+        <gpx version="1.1">
+            <wpt lat="45.5" lon="-122.5">
+                <name>Portland</name>
+            </wpt>
+        </gpx>
+        """.data(using: .utf8)!
+
+        let result = GPXService.parse(data: gpxData)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.waypoints.count, 1)
+        XCTAssertEqual(result?.waypoints.first?.name, "Portland")
+        XCTAssertEqual(result?.waypoints.first?.type, .waypoint)
+        XCTAssertNil(result?.waypoints.first?.elevationMeters)
+    }
+
+    func testParseWaypointTypes() {
+        let gpxData = """
+        <?xml version="1.0"?>
+        <gpx version="1.1">
+            <wpt lat="1.0" lon="1.0">
+                <name>Camp</name>
+                <type>campsite</type>
+            </wpt>
+            <wpt lat="2.0" lon="2.0">
+                <name>Supply</name>
+                <type>resupply</type>
+            </wpt>
+            <wpt lat="3.0" lon="3.0">
+                <name>Peak</name>
+                <type>summit</type>
+            </wpt>
+            <wpt lat="4.0" lon="4.0">
+                <name>Danger</name>
+                <type>hazard</type>
+            </wpt>
+        </gpx>
+        """.data(using: .utf8)!
+
+        let result = GPXService.parse(data: gpxData)
+
+        XCTAssertEqual(result?.waypoints.count, 4)
+        XCTAssertEqual(result?.waypoints[0].type, .campsite)
+        XCTAssertEqual(result?.waypoints[1].type, .resupply)
+        XCTAssertEqual(result?.waypoints[2].type, .summit)
+        XCTAssertEqual(result?.waypoints[3].type, .hazard)
+    }
+
+    func testParseInvalidXML() {
+        let invalidData = "This is not XML".data(using: .utf8)!
+        let result = GPXService.parse(data: invalidData)
+
+        // Should return nil for invalid XML
+        XCTAssertNil(result)
+    }
+
+    func testParseEmptyGPX() {
+        let gpxData = """
+        <?xml version="1.0"?>
+        <gpx version="1.1">
+        </gpx>
+        """.data(using: .utf8)!
+
+        let result = GPXService.parse(data: gpxData)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.waypoints.count, 0)
+        XCTAssertEqual(result?.trackPoints.count, 0)
+    }
+
+    // MARK: - Round Trip Tests
+
+    func testExportThenParse() {
+        let originalWaypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Start",
+                type: .startPoint,
+                elevationMeters: 1000,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+                name: "End",
+                type: .endPoint,
+                elevationMeters: 2000,
+                sourceId: UUID()
+            )
+        ]
+
+        let originalTrack = [
+            CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0)
+        ]
+
+        // Export
+        let gpxString = GPXService.export(
+            waypoints: originalWaypoints,
+            trackCoordinates: originalTrack,
+            name: "Round Trip Test"
+        )
+
+        // Parse back
+        let gpxData = gpxString.data(using: .utf8)!
+        let result = GPXService.parse(data: gpxData)
+
+        // Verify
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.name, "Round Trip Test")
+        XCTAssertEqual(result?.waypoints.count, 2)
+        XCTAssertEqual(result?.trackPoints.count, 2)
+
+        // Check waypoint data preserved
+        XCTAssertEqual(result?.waypoints[0].name, "Start")
+        XCTAssertEqual(result?.waypoints[0].type, .startPoint)
+        XCTAssertEqual(result?.waypoints[0].elevationMeters, 1000)
+
+        XCTAssertEqual(result?.waypoints[1].name, "End")
+        XCTAssertEqual(result?.waypoints[1].type, .endPoint)
+        XCTAssertEqual(result?.waypoints[1].elevationMeters, 2000)
+
+        // Check coordinates
+        XCTAssertEqual(result?.trackPoints[0].latitude, 40.0)
+        XCTAssertEqual(result?.trackPoints[0].longitude, -74.0)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlannerTests/RouteServiceTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/RouteServiceTests.swift
@@ -1,0 +1,359 @@
+import XCTest
+import CoreLocation
+@testable import ExpeditionPlanner
+
+final class RouteServiceTests: XCTestCase {
+
+    // MARK: - Waypoint Type Tests
+
+    func testWaypointTypeIcons() {
+        for type in WaypointType.allCases {
+            XCTAssertFalse(type.icon.isEmpty, "\(type) should have an icon")
+        }
+    }
+
+    func testWaypointTypeColors() {
+        for type in WaypointType.allCases {
+            // Just verify it doesn't crash
+            _ = type.color
+        }
+    }
+
+    func testWaypointTypeSortOrder() {
+        // Start should come before end
+        XCTAssertLessThan(WaypointType.startPoint.sortOrder, WaypointType.endPoint.sortOrder)
+        // End should come before summit
+        XCTAssertLessThan(WaypointType.endPoint.sortOrder, WaypointType.summit.sortOrder)
+    }
+
+    // MARK: - Route Waypoint Tests
+
+    func testRouteWaypointEquality() {
+        let id = UUID()
+        let waypoint1 = RouteWaypoint(
+            id: id,
+            coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            name: "Test",
+            type: .waypoint,
+            sourceId: UUID()
+        )
+        let waypoint2 = RouteWaypoint(
+            id: id,
+            coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+            name: "Different",
+            type: .campsite,
+            sourceId: UUID()
+        )
+
+        // Same ID means equal
+        XCTAssertEqual(waypoint1, waypoint2)
+    }
+
+    func testRouteWaypointHashable() {
+        let waypoint1 = RouteWaypoint(
+            coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+            name: "Test1",
+            type: .waypoint,
+            sourceId: UUID()
+        )
+        let waypoint2 = RouteWaypoint(
+            coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+            name: "Test2",
+            type: .campsite,
+            sourceId: UUID()
+        )
+
+        var set = Set<RouteWaypoint>()
+        set.insert(waypoint1)
+        set.insert(waypoint2)
+
+        XCTAssertEqual(set.count, 2)
+    }
+
+    // MARK: - Waypoint Extraction from Itinerary Tests
+
+    func testExtractWaypointsFromEmptyItinerary() {
+        let emptyDays: [ItineraryDay] = []
+        let waypoints = RouteService.extractWaypoints(from: emptyDays)
+        XCTAssertTrue(waypoints.isEmpty)
+    }
+
+    func testExtractWaypointsFromSingleDay() {
+        let day = ItineraryDay(dayNumber: 1)
+        day.startLocation = "Trailhead"
+        day.endLocation = "Camp 1"
+        day.startLatitude = 40.0
+        day.startLongitude = -74.0
+        day.endLatitude = 40.5
+        day.endLongitude = -73.5
+        day.startElevationMeters = 1000
+        day.endElevationMeters = 2000
+
+        let waypoints = RouteService.extractWaypoints(from: [day])
+
+        // Should have start and end points
+        XCTAssertEqual(waypoints.count, 2)
+
+        // First should be start point
+        XCTAssertEqual(waypoints[0].name, "Trailhead")
+        XCTAssertEqual(waypoints[0].type, .startPoint)
+        XCTAssertEqual(waypoints[0].elevationMeters, 1000)
+
+        // Last should be end point (since it's the only day)
+        XCTAssertEqual(waypoints[1].name, "Camp 1")
+        XCTAssertEqual(waypoints[1].type, .endPoint)
+        XCTAssertEqual(waypoints[1].elevationMeters, 2000)
+    }
+
+    func testExtractWaypointsMultipleDays() {
+        let day1 = ItineraryDay(dayNumber: 1)
+        day1.startLocation = "Trailhead"
+        day1.endLocation = "Camp 1"
+        day1.campName = "First Camp"
+        day1.startLatitude = 40.0
+        day1.startLongitude = -74.0
+        day1.endLatitude = 40.5
+        day1.endLongitude = -73.5
+
+        let day2 = ItineraryDay(dayNumber: 2)
+        day2.endLocation = "Camp 2"
+        day2.endLatitude = 41.0
+        day2.endLongitude = -73.0
+        day2.campName = "Second Camp"
+
+        let day3 = ItineraryDay(dayNumber: 3)
+        day3.endLocation = "End"
+        day3.endLatitude = 41.5
+        day3.endLongitude = -72.5
+
+        let waypoints = RouteService.extractWaypoints(from: [day1, day2, day3])
+
+        // Should have: start (1), camp1 end (1), camp2 end (2), end (3)
+        XCTAssertEqual(waypoints.count, 4)
+
+        XCTAssertEqual(waypoints[0].type, .startPoint)
+        XCTAssertEqual(waypoints[1].type, .campsite) // Has campName
+        XCTAssertEqual(waypoints[2].type, .campsite) // Has campName
+        XCTAssertEqual(waypoints[3].type, .endPoint) // Last day
+    }
+
+    func testExtractSummitWaypoint() {
+        let day = ItineraryDay(dayNumber: 1, activityType: .summit)
+        day.endLocation = "Peak"
+        day.endLatitude = 40.0
+        day.endLongitude = -74.0
+
+        let day2 = ItineraryDay(dayNumber: 2)
+        day2.endLocation = "End"
+        day2.endLatitude = 41.0
+        day2.endLongitude = -73.0
+
+        let waypoints = RouteService.extractWaypoints(from: [day, day2])
+
+        // First end should be summit type
+        let summitWaypoint = waypoints.first { $0.name == "Peak" }
+        XCTAssertEqual(summitWaypoint?.type, .summit)
+    }
+
+    // MARK: - Waypoint Extraction from Resupply Points
+
+    func testExtractWaypointsFromResupplyPoints() {
+        let resupply1 = ResupplyPoint(name: "Coldfoot")
+        resupply1.latitude = 67.25
+        resupply1.longitude = -150.17
+        resupply1.elevationMeters = 300
+        resupply1.dayNumber = 5
+        resupply1.hasPostOffice = true
+        resupply1.hasGroceries = true
+
+        let resupply2 = ResupplyPoint(name: "Circle City")
+        resupply2.latitude = 65.82
+        resupply2.longitude = -144.06
+
+        let waypoints = RouteService.extractWaypoints(from: [resupply1, resupply2])
+
+        XCTAssertEqual(waypoints.count, 2)
+        XCTAssertEqual(waypoints[0].type, .resupply)
+        XCTAssertEqual(waypoints[0].name, "Coldfoot")
+        XCTAssertEqual(waypoints[0].elevationMeters, 300)
+        XCTAssertEqual(waypoints[0].dayNumber, 5)
+        XCTAssertTrue(waypoints[0].notes?.contains("Post Office") ?? false)
+    }
+
+    func testExtractResupplyWithoutCoordinates() {
+        let resupply = ResupplyPoint(name: "No Location")
+        // No coordinates set
+
+        let waypoints = RouteService.extractWaypoints(from: [resupply])
+
+        // Should be filtered out
+        XCTAssertTrue(waypoints.isEmpty)
+    }
+
+    // MARK: - Route Building Tests
+
+    func testBuildRouteEmpty() {
+        let route = RouteService.buildRoute(from: [])
+        XCTAssertTrue(route.isEmpty)
+    }
+
+    func testBuildRouteFromDays() {
+        let day1 = ItineraryDay(dayNumber: 1)
+        day1.startLatitude = 40.0
+        day1.startLongitude = -74.0
+        day1.endLatitude = 40.5
+        day1.endLongitude = -73.5
+
+        let day2 = ItineraryDay(dayNumber: 2)
+        day2.endLatitude = 41.0
+        day2.endLongitude = -73.0
+
+        let route = RouteService.buildRoute(from: [day1, day2])
+
+        XCTAssertEqual(route.count, 3)
+        XCTAssertEqual(route[0].latitude, 40.0)
+        XCTAssertEqual(route[1].latitude, 40.5)
+        XCTAssertEqual(route[2].latitude, 41.0)
+    }
+
+    func testBuildRouteRemovesDuplicates() {
+        let day1 = ItineraryDay(dayNumber: 1)
+        day1.startLatitude = 40.0
+        day1.startLongitude = -74.0
+        day1.endLatitude = 40.5
+        day1.endLongitude = -73.5
+
+        let day2 = ItineraryDay(dayNumber: 2)
+        // Start same as day1 end
+        day2.startLatitude = 40.5
+        day2.startLongitude = -73.5
+        day2.endLatitude = 41.0
+        day2.endLongitude = -73.0
+
+        let route = RouteService.buildRoute(from: [day1, day2])
+
+        // Should not duplicate the connection point
+        XCTAssertEqual(route.count, 3)
+    }
+
+    // MARK: - Statistics Tests
+
+    func testRouteStatistics() {
+        let waypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Start",
+                type: .startPoint,
+                elevationMeters: 1000,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.5, longitude: -73.5),
+                name: "Camp",
+                type: .campsite,
+                elevationMeters: 2000,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+                name: "Summit",
+                type: .summit,
+                elevationMeters: 3000,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.5, longitude: -72.5),
+                name: "End",
+                type: .endPoint,
+                elevationMeters: 1500,
+                sourceId: UUID()
+            )
+        ]
+
+        let route = waypoints.map { $0.coordinate }
+        let stats = RouteService.statistics(waypoints: waypoints, route: route)
+
+        XCTAssertEqual(stats.waypointCount, 4)
+        XCTAssertEqual(stats.campsiteCount, 1)
+        XCTAssertEqual(stats.summitCount, 1)
+        XCTAssertEqual(stats.highestElevationMeters, 3000)
+        XCTAssertEqual(stats.lowestElevationMeters, 1000)
+        XCTAssertGreaterThan(stats.totalDistanceMeters, 0)
+    }
+
+    // MARK: - Filtering Tests
+
+    func testFilterByType() {
+        let waypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Start",
+                type: .startPoint,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.5, longitude: -73.5),
+                name: "Camp",
+                type: .campsite,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+                name: "Supply",
+                type: .resupply,
+                sourceId: UUID()
+            )
+        ]
+
+        let campsitesOnly = RouteService.filter(waypoints: waypoints, by: [.campsite])
+        XCTAssertEqual(campsitesOnly.count, 1)
+        XCTAssertEqual(campsitesOnly[0].name, "Camp")
+
+        let multipleTypes = RouteService.filter(waypoints: waypoints, by: [.startPoint, .resupply])
+        XCTAssertEqual(multipleTypes.count, 2)
+
+        let empty = RouteService.filter(waypoints: waypoints, by: [])
+        XCTAssertEqual(empty.count, 3) // Empty set returns all
+    }
+
+    func testFilterByDayRange() {
+        let waypoints = [
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.0, longitude: -74.0),
+                name: "Day 1",
+                type: .waypoint,
+                dayNumber: 1,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 40.5, longitude: -73.5),
+                name: "Day 3",
+                type: .waypoint,
+                dayNumber: 3,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.0, longitude: -73.0),
+                name: "Day 5",
+                type: .waypoint,
+                dayNumber: 5,
+                sourceId: UUID()
+            ),
+            RouteWaypoint(
+                coordinate: CLLocationCoordinate2D(latitude: 41.5, longitude: -72.5),
+                name: "No Day",
+                type: .waypoint,
+                sourceId: UUID()
+            )
+        ]
+
+        let days2to4 = RouteService.filter(waypoints: waypoints, fromDay: 2, toDay: 4)
+        XCTAssertEqual(days2to4.count, 2) // Day 3 + No Day (included because no day number)
+
+        let fromDay3 = RouteService.filter(waypoints: waypoints, fromDay: 3, toDay: nil)
+        XCTAssertEqual(fromDay3.count, 3) // Day 3, Day 5, No Day
+
+        let toDay3 = RouteService.filter(waypoints: waypoints, fromDay: nil, toDay: 3)
+        XCTAssertEqual(toDay3.count, 3) // Day 1, Day 3, No Day
+    }
+}


### PR DESCRIPTION
## Summary
- Add full expedition route map visualization with waypoints, polylines, and distance calculations
- Implement GPX import/export for route data exchange
- Add current location tracking with distance traveled calculations
- Include Alaska/Yukon shelter cabin waypoints (11 sample locations)
- Implement offline map tile caching from OpenStreetMap
- Add elevation overlay toggle and route statistics display
- Add waypoint filtering by type and cache management in Settings

## Test plan
- [ ] Create expedition with itinerary days, verify route displays on map
- [ ] Import GPX file, verify waypoints are created
- [ ] Export GPX, verify file contains waypoints and track
- [ ] Enable location tracking, verify user position shows on map
- [ ] Toggle shelter waypoints, verify they appear near route
- [ ] Download offline map region, verify tiles are cached
- [ ] Clear map cache in Settings, verify cache is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)