### PR TITLE
Add pre-departure task checklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 # Xcode Build
 build/
 DerivedData/
-*.xcodeproj/xcuserdata/
-*.xcworkspace/xcuserdata/
+**/*.xcodeproj/xcuserdata/
+**/*.xcworkspace/xcuserdata/
 
 # macOS
 .DS_Store

--- a/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
+++ b/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
@@ -137,6 +137,13 @@
 		RMT01 /* DistanceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT101 /* DistanceServiceTests.swift */; };
 		RMT02 /* GPXServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT102 /* GPXServiceTests.swift */; };
 		RMT03 /* RouteServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMT103 /* RouteServiceTests.swift */; };
+		CL001 /* ChecklistItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL101 /* ChecklistItem.swift */; };
+		CL002 /* ChecklistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL102 /* ChecklistViewModel.swift */; };
+		CL003 /* ChecklistListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL103 /* ChecklistListView.swift */; };
+		CL004 /* ChecklistDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL104 /* ChecklistDetailView.swift */; };
+		CL005 /* ChecklistFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL105 /* ChecklistFormView.swift */; };
+		CL006 /* ChecklistRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL106 /* ChecklistRowView.swift */; };
+		CLT01 /* ChecklistItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CLT101 /* ChecklistItemTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -285,6 +292,13 @@
 		RMT101 /* DistanceServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceServiceTests.swift; sourceTree = "<group>"; };
 		RMT102 /* GPXServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXServiceTests.swift; sourceTree = "<group>"; };
 		RMT103 /* RouteServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteServiceTests.swift; sourceTree = "<group>"; };
+		CL101 /* ChecklistItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistItem.swift; sourceTree = "<group>"; };
+		CL102 /* ChecklistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistViewModel.swift; sourceTree = "<group>"; };
+		CL103 /* ChecklistListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistListView.swift; sourceTree = "<group>"; };
+		CL104 /* ChecklistDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistDetailView.swift; sourceTree = "<group>"; };
+		CL105 /* ChecklistFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistFormView.swift; sourceTree = "<group>"; };
+		CL106 /* ChecklistRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistRowView.swift; sourceTree = "<group>"; };
+		CLT101 /* ChecklistItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistItemTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -368,6 +382,7 @@
 				EC8E8443F18754BD48445A27 /* TransportLeg.swift */,
 				71203CF5DE80A45D4129DE9C /* Accommodation.swift */,
 				0418909D68337C695811A94A /* SatelliteDevice.swift */,
+				CL101 /* ChecklistItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -501,8 +516,21 @@
 				4F9D041395F4931688D7A7A1 /* Transport */,
 				AF73BF37A4B6D87F7855461F /* Accommodation */,
 				99A1B36E6E8868D608EF6698 /* SatelliteDevice */,
+				CLGRP /* Checklist */,
 			);
 			name = Logistics;
+			sourceTree = "<group>";
+		};
+		CLGRP /* Checklist */ = {
+			isa = PBXGroup;
+			children = (
+				CL103 /* ChecklistListView.swift */,
+				CL106 /* ChecklistRowView.swift */,
+				CL104 /* ChecklistDetailView.swift */,
+				CL105 /* ChecklistFormView.swift */,
+			);
+			name = Checklist;
+			path = Logistics/Checklist;
 			sourceTree = "<group>";
 		};
 		BCBD4D347997095576824E40 /* Services */ = {
@@ -580,6 +608,7 @@
 				RMT101 /* DistanceServiceTests.swift */,
 				RMT102 /* GPXServiceTests.swift */,
 				RMT103 /* RouteServiceTests.swift */,
+				CLT101 /* ChecklistItemTests.swift */,
 			);
 			path = ExpeditionPlannerTests;
 			sourceTree = "<group>";
@@ -630,6 +659,7 @@
 				2FC2A9CE7DFE26A05B3D01D6 /* TransportViewModel.swift */,
 				8C6E4BDE40E727E8662D2B36 /* AccommodationViewModel.swift */,
 				782368A25AAF9F42F3ABE1F2 /* SatelliteDeviceViewModel.swift */,
+				CL102 /* ChecklistViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -853,6 +883,12 @@
 				B7D422C03738923FB8BC212A /* SatelliteDeviceListView.swift in Sources */,
 				893BB1002E9669FC69C68A7A /* SatelliteDeviceDetailView.swift in Sources */,
 				EE3C0833CD9F39DE7F1C6DD5 /* SatelliteDeviceFormView.swift in Sources */,
+				CL001 /* ChecklistItem.swift in Sources */,
+				CL002 /* ChecklistViewModel.swift in Sources */,
+				CL003 /* ChecklistListView.swift in Sources */,
+				CL004 /* ChecklistDetailView.swift in Sources */,
+				CL005 /* ChecklistFormView.swift in Sources */,
+				CL006 /* ChecklistRowView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -873,6 +909,7 @@
 				RMT01 /* DistanceServiceTests.swift in Sources */,
 				RMT02 /* GPXServiceTests.swift in Sources */,
 				RMT03 /* RouteServiceTests.swift in Sources */,
+				CLT01 /* ChecklistItemTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExpeditionPlanner/ExpeditionPlanner/ChakiApp.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ChakiApp.swift
@@ -31,7 +31,8 @@ struct ChakiApp: App {
                 RiskAssessment.self,
                 InsurancePolicy.self,
                 Shelter.self,
-                HistoricalClimate.self
+                HistoricalClimate.self,
+                ChecklistItem.self
             ])
 
             let cloudKitDatabase: ModelConfiguration.CloudKitDatabase

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/ChecklistItem.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/ChecklistItem.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftData
+
+// MARK: - Checklist Status
+
+enum ChecklistStatus: String, Codable, CaseIterable {
+    case pending = "Pending"
+    case inProgress = "In Progress"
+    case completed = "Completed"
+    case skipped = "Skipped"
+
+    var icon: String {
+        switch self {
+        case .pending: return "circle"
+        case .inProgress: return "circle.dotted.circle"
+        case .completed: return "checkmark.circle.fill"
+        case .skipped: return "slash.circle"
+        }
+    }
+}
+
+// MARK: - Checklist Category
+
+enum ChecklistCategory: String, Codable, CaseIterable {
+    case permits = "Permits"
+    case gear = "Gear"
+    case logistics = "Logistics"
+    case medical = "Medical"
+    case travel = "Travel"
+    case training = "Training"
+    case communication = "Communication"
+    case other = "Other"
+
+    var icon: String {
+        switch self {
+        case .permits: return "doc.text"
+        case .gear: return "backpack"
+        case .logistics: return "shippingbox"
+        case .medical: return "cross.case"
+        case .travel: return "airplane"
+        case .training: return "figure.hiking"
+        case .communication: return "antenna.radiowaves.left.and.right"
+        case .other: return "ellipsis.circle"
+        }
+    }
+}
+
+// MARK: - Checklist Item
+
+@Model
+final class ChecklistItem {
+    var id: UUID = UUID()
+    var title: String = ""
+    var notes: String = ""
+    var status: ChecklistStatus = ChecklistStatus.pending
+    var category: ChecklistCategory = ChecklistCategory.logistics
+    var dueDate: Date?
+    var dueOffset: Int?
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+
+    // Relationships - must be optional for CloudKit
+    var assignedTo: Participant?
+    var expedition: Expedition?
+
+    init(
+        title: String = "",
+        notes: String = "",
+        status: ChecklistStatus = .pending,
+        category: ChecklistCategory = .logistics,
+        dueDate: Date? = nil,
+        dueOffset: Int? = nil
+    ) {
+        self.id = UUID()
+        self.title = title
+        self.notes = notes
+        self.status = status
+        self.category = category
+        self.dueDate = dueDate
+        self.dueOffset = dueOffset
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+
+    // MARK: - Computed Properties
+
+    var isComplete: Bool {
+        status == .completed
+    }
+
+    var isSkipped: Bool {
+        status == .skipped
+    }
+
+    var statusColor: String {
+        switch status {
+        case .pending: return "gray"
+        case .inProgress: return "blue"
+        case .completed: return "green"
+        case .skipped: return "orange"
+        }
+    }
+
+    // MARK: - Due Date Helpers
+
+    func computedDueDate(expeditionStartDate: Date?) -> Date? {
+        if let dueDate {
+            return dueDate
+        }
+        guard let offset = dueOffset, let startDate = expeditionStartDate else {
+            return nil
+        }
+        return Calendar.current.date(byAdding: .day, value: offset, to: startDate)
+    }
+
+    func isOverdue(expeditionStartDate: Date?) -> Bool {
+        guard !isComplete, !isSkipped else { return false }
+        guard let due = computedDueDate(expeditionStartDate: expeditionStartDate) else {
+            return false
+        }
+        return due < Date()
+    }
+
+    func daysUntilDue(expeditionStartDate: Date?) -> Int? {
+        guard let due = computedDueDate(expeditionStartDate: expeditionStartDate) else {
+            return nil
+        }
+        let fromDate = Calendar.current.startOfDay(for: Date())
+        let toDate = Calendar.current.startOfDay(for: due)
+        return Calendar.current.dateComponents([.day], from: fromDate, to: toDate).day
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/Expedition.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/Expedition.swift
@@ -51,6 +51,9 @@ final class Expedition {
     @Relationship(deleteRule: .cascade, inverse: \SatelliteDevice.expedition)
     var satelliteDevices: [SatelliteDevice]?
 
+    @Relationship(deleteRule: .cascade, inverse: \ChecklistItem.expedition)
+    var checklistItems: [ChecklistItem]?
+
     init(
         name: String = "",
         expeditionDescription: String = "",

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/Participant.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/Participant.swift
@@ -39,6 +39,9 @@ final class Participant {
     @Relationship(deleteRule: .nullify, inverse: \TransportLeg.participant)
     var transportLegs: [TransportLeg]?
 
+    @Relationship(deleteRule: .nullify, inverse: \ChecklistItem.assignedTo)
+    var checklistAssignments: [ChecklistItem]?
+
     init(
         name: String = "",
         email: String = "",

--- a/ExpeditionPlanner/ExpeditionPlanner/ViewModels/ChecklistViewModel.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ViewModels/ChecklistViewModel.swift
@@ -1,0 +1,199 @@
+import Foundation
+import SwiftData
+import OSLog
+
+private let logger = Logger(subsystem: "com.chaki.app", category: "ChecklistViewModel")
+
+enum ChecklistSortOrder: String, CaseIterable {
+    case dueDate = "Due Date"
+    case category = "Category"
+    case status = "Status"
+    case title = "Title"
+}
+
+@Observable
+final class ChecklistViewModel {
+    private var modelContext: ModelContext
+
+    var items: [ChecklistItem] = []
+    var searchText: String = ""
+    var filterStatus: ChecklistStatus?
+    var filterCategory: ChecklistCategory?
+    var sortOrder: ChecklistSortOrder = .dueDate
+    var errorMessage: String?
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Load Data
+
+    func loadItems(for expedition: Expedition) {
+        let allItems = expedition.checklistItems ?? []
+
+        var filtered = allItems
+
+        // Apply search filter
+        if !searchText.isEmpty {
+            filtered = filtered.filter { item in
+                item.title.localizedCaseInsensitiveContains(searchText) ||
+                item.notes.localizedCaseInsensitiveContains(searchText) ||
+                (item.assignedTo?.name.localizedCaseInsensitiveContains(searchText) ?? false)
+            }
+        }
+
+        // Apply status filter
+        if let status = filterStatus {
+            filtered = filtered.filter { $0.status == status }
+        }
+
+        // Apply category filter
+        if let category = filterCategory {
+            filtered = filtered.filter { $0.category == category }
+        }
+
+        // Sort
+        let startDate = expedition.startDate
+        switch sortOrder {
+        case .dueDate:
+            items = filtered.sorted {
+                let date0 = $0.computedDueDate(expeditionStartDate: startDate) ?? .distantFuture
+                let date1 = $1.computedDueDate(expeditionStartDate: startDate) ?? .distantFuture
+                if date0 != date1 { return date0 < date1 }
+                return $0.title < $1.title
+            }
+        case .category:
+            items = filtered.sorted {
+                if $0.category != $1.category { return $0.category.rawValue < $1.category.rawValue }
+                return $0.title < $1.title
+            }
+        case .status:
+            items = filtered.sorted {
+                if $0.status != $1.status { return $0.status.rawValue < $1.status.rawValue }
+                return $0.title < $1.title
+            }
+        case .title:
+            items = filtered.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        }
+    }
+
+    // MARK: - CRUD Operations
+
+    func addItem(_ item: ChecklistItem, to expedition: Expedition) {
+        item.expedition = expedition
+        if expedition.checklistItems == nil {
+            expedition.checklistItems = []
+        }
+        expedition.checklistItems?.append(item)
+        modelContext.insert(item)
+
+        logger.info("Added checklist item '\(item.title)' to expedition")
+        saveContext()
+        loadItems(for: expedition)
+    }
+
+    func updateItem(_ item: ChecklistItem, in expedition: Expedition) {
+        item.updatedAt = Date()
+        logger.debug("Updated checklist item '\(item.title)'")
+        saveContext()
+        loadItems(for: expedition)
+    }
+
+    func deleteItem(_ item: ChecklistItem, from expedition: Expedition) {
+        let title = item.title
+        expedition.checklistItems?.removeAll { $0.id == item.id }
+        modelContext.delete(item)
+
+        logger.info("Deleted checklist item '\(title)' from expedition")
+        saveContext()
+        loadItems(for: expedition)
+    }
+
+    func toggleStatus(for item: ChecklistItem, in expedition: Expedition) {
+        switch item.status {
+        case .pending:
+            item.status = .inProgress
+        case .inProgress:
+            item.status = .completed
+        case .completed:
+            item.status = .pending
+        case .skipped:
+            item.status = .pending
+        }
+        item.updatedAt = Date()
+        logger.debug("Toggled checklist item '\(item.title)' to \(item.status.rawValue)")
+        saveContext()
+        loadItems(for: expedition)
+    }
+
+    // MARK: - Computed Properties
+
+    func overdueItems(startDate: Date?) -> [ChecklistItem] {
+        items.filter { $0.isOverdue(expeditionStartDate: startDate) }
+    }
+
+    func upcomingItems(startDate: Date?, withinDays: Int = 30) -> [ChecklistItem] {
+        items.filter { item in
+            guard !item.isComplete, !item.isSkipped else { return false }
+            guard let days = item.daysUntilDue(expeditionStartDate: startDate) else { return false }
+            return days >= 0 && days <= withinDays && !item.isOverdue(expeditionStartDate: startDate)
+        }
+    }
+
+    var completedCount: Int {
+        items.filter { $0.isComplete }.count
+    }
+
+    var pendingCount: Int {
+        items.filter { $0.status == .pending }.count
+    }
+
+    var inProgressCount: Int {
+        items.filter { $0.status == .inProgress }.count
+    }
+
+    var completionPercentage: Double {
+        guard !items.isEmpty else { return 0 }
+        return Double(completedCount) / Double(items.count) * 100
+    }
+
+    var groupedByCategory: [(category: ChecklistCategory, items: [ChecklistItem])] {
+        let grouped = Dictionary(grouping: items) { $0.category }
+        return ChecklistCategory.allCases.compactMap { category in
+            guard let list = grouped[category], !list.isEmpty else { return nil }
+            return (category: category, items: list)
+        }
+    }
+
+    var groupedByStatus: [(status: ChecklistStatus, items: [ChecklistItem])] {
+        let grouped = Dictionary(grouping: items) { $0.status }
+        return ChecklistStatus.allCases.compactMap { status in
+            guard let list = grouped[status], !list.isEmpty else { return nil }
+            return (status: status, items: list)
+        }
+    }
+
+    // MARK: - Filtering
+
+    func clearFilters() {
+        searchText = ""
+        filterStatus = nil
+        filterCategory = nil
+    }
+
+    var hasActiveFilters: Bool {
+        filterStatus != nil || filterCategory != nil || !searchText.isEmpty
+    }
+
+    // MARK: - Private
+
+    private func saveContext() {
+        do {
+            try modelContext.save()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Failed to save: \(error.localizedDescription)"
+            logger.error("Failed to save checklist changes: \(error.localizedDescription)")
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
@@ -120,6 +120,15 @@ struct ExpeditionDetailView: View {
                         detail: satelliteDevicesDetail
                     )
                 }
+
+                NavigationLink(value: ExpeditionSection.checklist) {
+                    SectionRow(
+                        title: "Pre-Departure Tasks",
+                        icon: "checklist",
+                        color: .mint,
+                        detail: checklistDetail
+                    )
+                }
             } header: {
                 Text("Logistics")
             }
@@ -279,6 +288,15 @@ struct ExpeditionDetailView: View {
         }
     }
 
+    private var checklistDetail: String {
+        let items = expedition.checklistItems ?? []
+        if items.isEmpty {
+            return "No tasks"
+        }
+        let done = items.filter { $0.isComplete }.count
+        return "\(done)/\(items.count) done"
+    }
+
     private var satelliteDevicesDetail: String {
         let count = (expedition.satelliteDevices ?? []).count
         if count == 0 {
@@ -314,6 +332,8 @@ struct ExpeditionDetailView: View {
             PermitListView(expedition: expedition)
         case .satelliteDevices:
             SatelliteDeviceListView(expedition: expedition)
+        case .checklist:
+            ChecklistListView(expedition: expedition)
         case .gear:
             GearListView(expedition: expedition)
         case .budget:
@@ -345,6 +365,7 @@ enum ExpeditionSection: Hashable {
     case resupply
     case permits
     case satelliteDevices
+    case checklist
     case gear
     case budget
     case safety

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistDetailView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistDetailView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+import SwiftData
+
+struct ChecklistDetailView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let item: ChecklistItem
+    let expedition: Expedition
+    var viewModel: ChecklistViewModel
+
+    @State private var showingEditSheet = false
+    @State private var showingDeleteAlert = false
+
+    var body: some View {
+        List {
+            // Header
+            Section {
+                headerView
+            }
+
+            // Status & Deadline
+            Section {
+                LabeledContent("Status") {
+                    HStack(spacing: 4) {
+                        Image(systemName: item.status.icon)
+                        Text(item.status.rawValue)
+                    }
+                    .foregroundStyle(statusColor)
+                }
+
+                LabeledContent("Category") {
+                    Label(item.category.rawValue, systemImage: item.category.icon)
+                }
+
+                if let due = item.computedDueDate(expeditionStartDate: expedition.startDate) {
+                    LabeledContent("Due Date") {
+                        Text(due.formatted(date: .long, time: .omitted))
+                            .foregroundStyle(dueDateColor)
+                    }
+
+                    if let days = item.daysUntilDue(expeditionStartDate: expedition.startDate) {
+                        LabeledContent("Days Until Due") {
+                            Text(daysLabel(days))
+                                .foregroundStyle(dueDateColor)
+                        }
+                    }
+                }
+
+                if let offset = item.dueOffset {
+                    LabeledContent("Offset from Start") {
+                        Text("\(abs(offset)) days \(offset < 0 ? "before" : "after")")
+                    }
+                }
+            } header: {
+                Label("Status & Deadline", systemImage: "clock")
+            }
+
+            // Assignment
+            if let participant = item.assignedTo {
+                Section {
+                    LabeledContent("Assigned To", value: participant.displayName)
+                    if !participant.email.isEmpty {
+                        LabeledContent("Email", value: participant.email)
+                    }
+                } header: {
+                    Label("Assignment", systemImage: "person")
+                }
+            }
+
+            // Notes
+            if !item.notes.isEmpty {
+                Section {
+                    Text(item.notes)
+                } header: {
+                    Text("Notes")
+                }
+            }
+
+            // Timestamps
+            Section {
+                LabeledContent("Created") {
+                    Text(item.createdAt.formatted(date: .abbreviated, time: .shortened))
+                }
+                LabeledContent("Updated") {
+                    Text(item.updatedAt.formatted(date: .abbreviated, time: .shortened))
+                }
+            } header: {
+                Text("Details")
+            }
+
+            // Actions
+            Section {
+                Button(role: .destructive) {
+                    showingDeleteAlert = true
+                } label: {
+                    Label("Delete Task", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle("Task Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Edit") {
+                    showingEditSheet = true
+                }
+            }
+
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") {
+                    dismiss()
+                }
+            }
+        }
+        .sheet(isPresented: $showingEditSheet) {
+            NavigationStack {
+                ChecklistFormView(
+                    mode: .edit(item),
+                    expedition: expedition,
+                    viewModel: viewModel
+                )
+            }
+        }
+        .alert("Delete Task?", isPresented: $showingDeleteAlert) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                viewModel.deleteItem(item, from: expedition)
+                dismiss()
+            }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    // MARK: - Header View
+
+    private var headerView: some View {
+        HStack(spacing: 16) {
+            Image(systemName: item.category.icon)
+                .font(.largeTitle)
+                .foregroundStyle(categoryColor)
+                .frame(width: 60, height: 60)
+                .background(categoryColor.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text(item.category.rawValue)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Text(item.status.rawValue)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(statusColor.opacity(0.2))
+                        .foregroundStyle(statusColor)
+                        .clipShape(Capsule())
+
+                    if item.isOverdue(expeditionStartDate: expedition.startDate) {
+                        Text("Overdue")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(Color.red.opacity(0.2))
+                            .foregroundStyle(.red)
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func daysLabel(_ days: Int) -> String {
+        if days < 0 {
+            return "\(abs(days)) days overdue"
+        } else if days == 0 {
+            return "Due today"
+        } else {
+            return "In \(days) days"
+        }
+    }
+
+    private var statusColor: Color {
+        switch item.statusColor {
+        case "green": return .green
+        case "blue": return .blue
+        case "orange": return .orange
+        default: return .secondary
+        }
+    }
+
+    private var dueDateColor: Color {
+        if item.isOverdue(expeditionStartDate: expedition.startDate) {
+            return .red
+        }
+        if let days = item.daysUntilDue(expeditionStartDate: expedition.startDate), days <= 7 {
+            return .orange
+        }
+        return .primary
+    }
+
+    private var categoryColor: Color {
+        switch item.category {
+        case .permits: return .gray
+        case .gear: return .green
+        case .logistics: return .brown
+        case .medical: return .red
+        case .travel: return .blue
+        case .training: return .orange
+        case .communication: return .purple
+        case .other: return .secondary
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistFormView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistFormView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import SwiftData
+
+enum ChecklistFormMode {
+    case create
+    case edit(ChecklistItem)
+}
+
+struct ChecklistFormView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let mode: ChecklistFormMode
+    let expedition: Expedition
+    var viewModel: ChecklistViewModel
+
+    // Form fields
+    @State private var title: String = ""
+    @State private var notes: String = ""
+    @State private var category: ChecklistCategory = .logistics
+    @State private var status: ChecklistStatus = .pending
+    @State private var assignedToID: UUID?
+
+    // Deadline - explicit date
+    @State private var hasExplicitDate: Bool = false
+    @State private var dueDate: Date = Date()
+
+    // Deadline - offset from start
+    @State private var hasOffset: Bool = false
+    @State private var offsetDays: Int = 30
+
+    private var isEditing: Bool {
+        if case .edit = mode { return true }
+        return false
+    }
+
+    private var navigationTitle: String {
+        isEditing ? "Edit Task" : "New Task"
+    }
+
+    private var existingItem: ChecklistItem? {
+        if case .edit(let item) = mode {
+            return item
+        }
+        return nil
+    }
+
+    private var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        Form {
+            // Basic Info
+            Section {
+                TextField("Title", text: $title)
+
+                Picker("Category", selection: $category) {
+                    ForEach(ChecklistCategory.allCases, id: \.self) { cat in
+                        Label(cat.rawValue, systemImage: cat.icon)
+                            .tag(cat)
+                    }
+                }
+
+                Picker("Status", selection: $status) {
+                    ForEach(ChecklistStatus.allCases, id: \.self) { stat in
+                        Label(stat.rawValue, systemImage: stat.icon)
+                            .tag(stat)
+                    }
+                }
+            } header: {
+                Text("Basic Info")
+            }
+
+            // Notes
+            Section {
+                VStack(alignment: .leading) {
+                    Text("Notes")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 60)
+                }
+            } header: {
+                Text("Notes")
+            }
+
+            // Deadline
+            Section {
+                Toggle("Specific Date", isOn: $hasExplicitDate)
+                if hasExplicitDate {
+                    DatePicker("Due Date", selection: $dueDate, displayedComponents: .date)
+                }
+
+                Toggle("Relative to Start Date", isOn: $hasOffset)
+                if hasOffset {
+                    Stepper(
+                        "\(offsetDays) days before start",
+                        value: $offsetDays,
+                        in: 1...365
+                    )
+                    if let startDate = expedition.startDate {
+                        let computed = Calendar.current.date(
+                            byAdding: .day, value: -offsetDays, to: startDate
+                        )
+                        if let computed {
+                            Text("= \(computed.formatted(date: .long, time: .omitted))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text("Set expedition start date to see computed date")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+            } header: {
+                Text("Deadline")
+            } footer: {
+                if hasExplicitDate && hasOffset {
+                    Text("Specific date takes priority over relative offset.")
+                }
+            }
+
+            // Assignment
+            Section {
+                Picker("Assigned To", selection: $assignedToID) {
+                    Text("Unassigned").tag(nil as UUID?)
+                    ForEach(expedition.participants ?? []) { participant in
+                        Text(participant.displayName).tag(participant.id as UUID?)
+                    }
+                }
+            } header: {
+                Text("Assignment")
+            }
+        }
+        .navigationTitle(navigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    dismiss()
+                }
+            }
+
+            ToolbarItem(placement: .confirmationAction) {
+                Button(isEditing ? "Save" : "Add") {
+                    saveItem()
+                }
+                .disabled(!canSave)
+            }
+        }
+        .onAppear {
+            loadExistingData()
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadExistingData() {
+        guard let item = existingItem else { return }
+
+        title = item.title
+        notes = item.notes
+        category = item.category
+        status = item.status
+        assignedToID = item.assignedTo?.id
+
+        if let date = item.dueDate {
+            dueDate = date
+            hasExplicitDate = true
+        }
+
+        if let offset = item.dueOffset {
+            offsetDays = abs(offset)
+            hasOffset = true
+        }
+    }
+
+    // MARK: - Save
+
+    private func saveItem() {
+        let participants = expedition.participants ?? []
+        let assignee = participants.first { $0.id == assignedToID }
+
+        if let existing = existingItem {
+            existing.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            existing.notes = notes
+            existing.category = category
+            existing.status = status
+            existing.assignedTo = assignee
+            existing.dueDate = hasExplicitDate ? dueDate : nil
+            existing.dueOffset = hasOffset ? -offsetDays : nil
+            existing.updatedAt = Date()
+
+            viewModel.updateItem(existing, in: expedition)
+        } else {
+            let item = ChecklistItem(
+                title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+                notes: notes,
+                status: status,
+                category: category,
+                dueDate: hasExplicitDate ? dueDate : nil,
+                dueOffset: hasOffset ? -offsetDays : nil
+            )
+            item.assignedTo = assignee
+
+            viewModel.addItem(item, to: expedition)
+        }
+
+        dismiss()
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ChecklistFormView(
+            mode: .create,
+            expedition: Expedition(name: "Test"),
+            viewModel: ChecklistViewModel(
+                // swiftlint:disable:next force_try
+                modelContext: try! ModelContainer(
+                    for: Expedition.self,
+                    configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+                ).mainContext
+            )
+        )
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistListView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistListView.swift
@@ -1,0 +1,335 @@
+import SwiftUI
+import SwiftData
+
+struct ChecklistListView: View {
+    @Environment(\.modelContext)
+    private var modelContext
+    @Bindable var expedition: Expedition
+
+    @State private var viewModel: ChecklistViewModel?
+    @State private var showingAddSheet = false
+    @State private var selectedItem: ChecklistItem?
+
+    var body: some View {
+        Group {
+            if let viewModel = viewModel {
+                checklistContent(viewModel: viewModel)
+            } else {
+                ProgressView()
+            }
+        }
+        .navigationTitle("Pre-Departure Tasks")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingAddSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+
+            if let viewModel = viewModel, !viewModel.items.isEmpty {
+                ToolbarItem(placement: .topBarLeading) {
+                    filterMenu(viewModel: viewModel)
+                }
+            }
+        }
+        .searchable(
+            text: Binding(
+                get: { viewModel?.searchText ?? "" },
+                set: { newValue in
+                    viewModel?.searchText = newValue
+                    viewModel?.loadItems(for: expedition)
+                }
+            ),
+            prompt: "Search tasks"
+        )
+        .sheet(isPresented: $showingAddSheet) {
+            if let viewModel = viewModel {
+                NavigationStack {
+                    ChecklistFormView(
+                        mode: .create,
+                        expedition: expedition,
+                        viewModel: viewModel
+                    )
+                }
+            }
+        }
+        .sheet(item: $selectedItem) { item in
+            if let viewModel = viewModel {
+                NavigationStack {
+                    ChecklistDetailView(
+                        item: item,
+                        expedition: expedition,
+                        viewModel: viewModel
+                    )
+                }
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = ChecklistViewModel(modelContext: modelContext)
+            }
+            viewModel?.loadItems(for: expedition)
+        }
+    }
+
+    // MARK: - List Content
+
+    @ViewBuilder
+    private func checklistContent(viewModel: ChecklistViewModel) -> some View {
+        if viewModel.items.isEmpty && !viewModel.hasActiveFilters {
+            ContentUnavailableView {
+                Label("No Tasks", systemImage: "checklist")
+            } description: {
+                Text("Add pre-departure tasks to track your expedition preparation.")
+            } actions: {
+                Button("Add Task") {
+                    showingAddSheet = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } else if viewModel.items.isEmpty {
+            ContentUnavailableView.search(text: viewModel.searchText)
+        } else {
+            List {
+                // Summary stats
+                Section {
+                    summaryView(viewModel: viewModel)
+                }
+
+                // Filter indicator
+                if viewModel.hasActiveFilters {
+                    Section {
+                        filterIndicator(viewModel: viewModel)
+                    }
+                }
+
+                // Overdue section
+                let overdue = viewModel.overdueItems(startDate: expedition.startDate)
+                if !overdue.isEmpty {
+                    Section {
+                        ForEach(overdue) { item in
+                            ChecklistRowView(
+                                item: item,
+                                expeditionStartDate: expedition.startDate
+                            ) {
+                                viewModel.toggleStatus(for: item, in: expedition)
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture { selectedItem = item }
+                        }
+                        .onDelete { indexSet in
+                            deleteItems(at: indexSet, from: overdue, viewModel: viewModel)
+                        }
+                    } header: {
+                        Label("Overdue", systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                // Upcoming section
+                let upcoming = viewModel.upcomingItems(startDate: expedition.startDate)
+                if !upcoming.isEmpty {
+                    Section {
+                        ForEach(upcoming) { item in
+                            ChecklistRowView(
+                                item: item,
+                                expeditionStartDate: expedition.startDate
+                            ) {
+                                viewModel.toggleStatus(for: item, in: expedition)
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture { selectedItem = item }
+                        }
+                        .onDelete { indexSet in
+                            deleteItems(at: indexSet, from: upcoming, viewModel: viewModel)
+                        }
+                    } header: {
+                        Label("Upcoming (30 days)", systemImage: "calendar.badge.clock")
+                    }
+                }
+
+                // Remaining items grouped by category
+                let overdueIDs = Set(overdue.map(\.id))
+                let upcomingIDs = Set(upcoming.map(\.id))
+                let remaining = viewModel.items.filter {
+                    !overdueIDs.contains($0.id) && !upcomingIDs.contains($0.id)
+                }
+
+                if !remaining.isEmpty {
+                    let grouped = Dictionary(grouping: remaining) { $0.category }
+                    ForEach(ChecklistCategory.allCases, id: \.self) { category in
+                        if let categoryItems = grouped[category], !categoryItems.isEmpty {
+                            Section {
+                                ForEach(categoryItems) { item in
+                                    ChecklistRowView(
+                                        item: item,
+                                        expeditionStartDate: expedition.startDate
+                                    ) {
+                                        viewModel.toggleStatus(for: item, in: expedition)
+                                    }
+                                    .contentShape(Rectangle())
+                                    .onTapGesture { selectedItem = item }
+                                }
+                                .onDelete { indexSet in
+                                    deleteItems(at: indexSet, from: categoryItems, viewModel: viewModel)
+                                }
+                            } header: {
+                                HStack {
+                                    Image(systemName: category.icon)
+                                    Text(category.rawValue)
+                                    Text("(\(categoryItems.count))")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Summary View
+
+    private func summaryView(viewModel: ChecklistViewModel) -> some View {
+        HStack(spacing: 16) {
+            StatBadge(
+                value: "\(viewModel.items.count)",
+                label: "Total",
+                icon: "checklist",
+                color: .blue
+            )
+            StatBadge(
+                value: "\(viewModel.completedCount)",
+                label: "Done",
+                icon: "checkmark.circle.fill",
+                color: .green
+            )
+            StatBadge(
+                value: "\(viewModel.inProgressCount)",
+                label: "In Progress",
+                icon: "circle.dotted.circle",
+                color: .orange
+            )
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Filter Indicator
+
+    private func filterIndicator(viewModel: ChecklistViewModel) -> some View {
+        HStack {
+            Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                .foregroundStyle(.blue)
+            Text("Filtered")
+                .font(.subheadline)
+            Spacer()
+            Button("Clear") {
+                viewModel.clearFilters()
+                viewModel.loadItems(for: expedition)
+            }
+            .font(.caption)
+            .foregroundStyle(.blue)
+        }
+    }
+
+    // MARK: - Filter Menu
+
+    @ViewBuilder
+    private func filterMenu(viewModel: ChecklistViewModel) -> some View {
+        Menu {
+            Button {
+                viewModel.clearFilters()
+                viewModel.loadItems(for: expedition)
+            } label: {
+                Label("Clear Filters", systemImage: viewModel.hasActiveFilters ? "" : "checkmark")
+            }
+
+            Divider()
+
+            Menu("Status") {
+                Button {
+                    viewModel.filterStatus = nil
+                    viewModel.loadItems(for: expedition)
+                } label: {
+                    Label("All Statuses", systemImage: viewModel.filterStatus == nil ? "checkmark" : "")
+                }
+
+                Divider()
+
+                ForEach(ChecklistStatus.allCases, id: \.self) { status in
+                    Button {
+                        viewModel.filterStatus = status
+                        viewModel.loadItems(for: expedition)
+                    } label: {
+                        Label(
+                            status.rawValue,
+                            systemImage: viewModel.filterStatus == status ? "checkmark" : status.icon
+                        )
+                    }
+                }
+            }
+
+            Menu("Category") {
+                Button {
+                    viewModel.filterCategory = nil
+                    viewModel.loadItems(for: expedition)
+                } label: {
+                    Label("All Categories", systemImage: viewModel.filterCategory == nil ? "checkmark" : "")
+                }
+
+                Divider()
+
+                ForEach(ChecklistCategory.allCases, id: \.self) { category in
+                    Button {
+                        viewModel.filterCategory = category
+                        viewModel.loadItems(for: expedition)
+                    } label: {
+                        Label(
+                            category.rawValue,
+                            systemImage: viewModel.filterCategory == category ? "checkmark" : category.icon
+                        )
+                    }
+                }
+            }
+
+            Divider()
+
+            Menu("Sort By") {
+                ForEach(ChecklistSortOrder.allCases, id: \.self) { order in
+                    Button {
+                        viewModel.sortOrder = order
+                        viewModel.loadItems(for: expedition)
+                    } label: {
+                        Label(order.rawValue, systemImage: viewModel.sortOrder == order ? "checkmark" : "")
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: viewModel.hasActiveFilters
+                ? "line.3.horizontal.decrease.circle.fill"
+                : "line.3.horizontal.decrease.circle")
+        }
+    }
+
+    // MARK: - Delete
+
+    private func deleteItems(
+        at indexSet: IndexSet,
+        from items: [ChecklistItem],
+        viewModel: ChecklistViewModel
+    ) {
+        for index in indexSet {
+            viewModel.deleteItem(items[index], from: expedition)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ChecklistListView(expedition: Expedition(name: "Test Expedition"))
+    }
+    .modelContainer(for: [Expedition.self, ChecklistItem.self], inMemory: true)
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistRowView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Logistics/Checklist/ChecklistRowView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct ChecklistRowView: View {
+    let item: ChecklistItem
+    let expeditionStartDate: Date?
+    var onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Status toggle button
+            Button {
+                onToggle()
+            } label: {
+                Image(systemName: item.status.icon)
+                    .font(.title2)
+                    .foregroundStyle(statusColor)
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.body)
+                    .strikethrough(item.isComplete)
+                    .foregroundStyle(item.isComplete ? .secondary : .primary)
+
+                HStack(spacing: 8) {
+                    Label(item.category.rawValue, systemImage: item.category.icon)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let participant = item.assignedTo {
+                        Label(participant.displayName, systemImage: "person")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let due = item.computedDueDate(expeditionStartDate: expeditionStartDate) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "calendar")
+                            .font(.caption2)
+                        Text(due.formatted(date: .abbreviated, time: .omitted))
+                            .font(.caption)
+                    }
+                    .foregroundStyle(dueDateColor)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Helpers
+
+    private var statusColor: Color {
+        switch item.statusColor {
+        case "green": return .green
+        case "blue": return .blue
+        case "orange": return .orange
+        default: return .secondary
+        }
+    }
+
+    private var dueDateColor: Color {
+        if item.isOverdue(expeditionStartDate: expeditionStartDate) {
+            return .red
+        }
+        if let days = item.daysUntilDue(expeditionStartDate: expeditionStartDate), days <= 7 {
+            return .orange
+        }
+        return .secondary
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlannerTests/ChecklistItemTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/ChecklistItemTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+import SwiftData
+@testable import Chaki
+
+final class ChecklistItemTests: XCTestCase {
+
+    // MARK: - Creation Tests
+
+    func testChecklistItemCreation() throws {
+        let item = ChecklistItem(
+            title: "Book flights",
+            notes: "Compare prices on Google Flights",
+            category: .travel
+        )
+
+        XCTAssertNotNil(item.id)
+        XCTAssertEqual(item.title, "Book flights")
+        XCTAssertEqual(item.notes, "Compare prices on Google Flights")
+        XCTAssertEqual(item.category, .travel)
+        XCTAssertEqual(item.status, .pending)
+    }
+
+    func testChecklistItemDefaultValues() throws {
+        let item = ChecklistItem()
+
+        XCTAssertEqual(item.title, "")
+        XCTAssertEqual(item.notes, "")
+        XCTAssertEqual(item.status, .pending)
+        XCTAssertEqual(item.category, .logistics)
+        XCTAssertNil(item.dueDate)
+        XCTAssertNil(item.dueOffset)
+        XCTAssertNil(item.assignedTo)
+        XCTAssertNil(item.expedition)
+    }
+
+    // MARK: - Computed Due Date Tests
+
+    func testComputedDueDateReturnsExplicitDate() throws {
+        let explicitDate = Date().adding(days: 14)
+        let item = ChecklistItem(title: "Test", dueDate: explicitDate, dueOffset: -30)
+
+        let computed = item.computedDueDate(expeditionStartDate: Date().adding(days: 60))
+        XCTAssertEqual(computed, explicitDate)
+    }
+
+    func testComputedDueDateFromOffset() throws {
+        let startDate = Date().adding(days: 60)
+        let item = ChecklistItem(title: "Test", dueOffset: -30)
+
+        let computed = item.computedDueDate(expeditionStartDate: startDate)
+        let expected = Calendar.current.date(byAdding: .day, value: -30, to: startDate)
+        XCTAssertEqual(computed, expected)
+    }
+
+    func testComputedDueDateNilWhenNoDateOrOffset() throws {
+        let item = ChecklistItem(title: "Test")
+
+        let computed = item.computedDueDate(expeditionStartDate: Date())
+        XCTAssertNil(computed)
+    }
+
+    func testComputedDueDateNilWhenOffsetButNoStartDate() throws {
+        let item = ChecklistItem(title: "Test", dueOffset: -30)
+
+        let computed = item.computedDueDate(expeditionStartDate: nil)
+        XCTAssertNil(computed)
+    }
+
+    // MARK: - Overdue Tests
+
+    func testIsOverdueForPastDueDate() throws {
+        let item = ChecklistItem(title: "Test", dueDate: Date().adding(days: -5))
+
+        XCTAssertTrue(item.isOverdue(expeditionStartDate: nil))
+    }
+
+    func testNotOverdueForFutureDueDate() throws {
+        let item = ChecklistItem(title: "Test", dueDate: Date().adding(days: 10))
+
+        XCTAssertFalse(item.isOverdue(expeditionStartDate: nil))
+    }
+
+    func testCompletedItemNotOverdue() throws {
+        let item = ChecklistItem(title: "Test", status: .completed, dueDate: Date().adding(days: -5))
+
+        XCTAssertFalse(item.isOverdue(expeditionStartDate: nil))
+    }
+
+    func testSkippedItemNotOverdue() throws {
+        let item = ChecklistItem(title: "Test", status: .skipped, dueDate: Date().adding(days: -5))
+
+        XCTAssertFalse(item.isOverdue(expeditionStartDate: nil))
+    }
+
+    func testNotOverdueWithNoDueDate() throws {
+        let item = ChecklistItem(title: "Test")
+
+        XCTAssertFalse(item.isOverdue(expeditionStartDate: nil))
+    }
+
+    // MARK: - Days Until Due Tests
+
+    func testDaysUntilDueForFutureDate() throws {
+        let item = ChecklistItem(title: "Test", dueDate: Date().adding(days: 15))
+
+        let days = item.daysUntilDue(expeditionStartDate: nil)
+        XCTAssertNotNil(days)
+        XCTAssertTrue(days == 14 || days == 15, "Expected 14 or 15 days, got \(days ?? -1)")
+    }
+
+    func testDaysUntilDueNilWhenNoDueDate() throws {
+        let item = ChecklistItem(title: "Test")
+
+        XCTAssertNil(item.daysUntilDue(expeditionStartDate: nil))
+    }
+
+    func testDaysUntilDueNegativeForPastDate() throws {
+        let item = ChecklistItem(title: "Test", dueDate: Date().adding(days: -5))
+
+        let days = item.daysUntilDue(expeditionStartDate: nil)
+        XCTAssertNotNil(days)
+        XCTAssertTrue((days ?? 0) < 0, "Expected negative days, got \(days ?? 0)")
+    }
+
+    // MARK: - Status Tests
+
+    func testIsComplete() throws {
+        let item = ChecklistItem(title: "Test", status: .completed)
+        XCTAssertTrue(item.isComplete)
+    }
+
+    func testNotCompleteForPending() throws {
+        let item = ChecklistItem(title: "Test", status: .pending)
+        XCTAssertFalse(item.isComplete)
+    }
+
+    func testIsSkipped() throws {
+        let item = ChecklistItem(title: "Test", status: .skipped)
+        XCTAssertTrue(item.isSkipped)
+    }
+
+    func testNotSkippedForInProgress() throws {
+        let item = ChecklistItem(title: "Test", status: .inProgress)
+        XCTAssertFalse(item.isSkipped)
+    }
+
+    // MARK: - Status Color Tests
+
+    func testStatusColorPending() throws {
+        let item = ChecklistItem(title: "Test", status: .pending)
+        XCTAssertEqual(item.statusColor, "gray")
+    }
+
+    func testStatusColorInProgress() throws {
+        let item = ChecklistItem(title: "Test", status: .inProgress)
+        XCTAssertEqual(item.statusColor, "blue")
+    }
+
+    func testStatusColorCompleted() throws {
+        let item = ChecklistItem(title: "Test", status: .completed)
+        XCTAssertEqual(item.statusColor, "green")
+    }
+
+    func testStatusColorSkipped() throws {
+        let item = ChecklistItem(title: "Test", status: .skipped)
+        XCTAssertEqual(item.statusColor, "orange")
+    }
+
+    // MARK: - Enum Coverage Tests
+
+    func testAllChecklistStatusesHaveIcons() throws {
+        for status in ChecklistStatus.allCases {
+            XCTAssertFalse(status.icon.isEmpty, "Status \(status.rawValue) has no icon")
+        }
+    }
+
+    func testAllChecklistCategoriesHaveIcons() throws {
+        for category in ChecklistCategory.allCases {
+            XCTAssertFalse(category.icon.isEmpty, "Category \(category.rawValue) has no icon")
+        }
+    }
+
+    func testChecklistStatusCount() throws {
+        XCTAssertEqual(ChecklistStatus.allCases.count, 4)
+    }
+
+    func testChecklistCategoryCount() throws {
+        XCTAssertEqual(ChecklistCategory.allCases.count, 8)
+    }
+
+    // MARK: - SwiftData Persistence Tests
+
+    func testSwiftDataPersistence() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Expedition.self, ChecklistItem.self, Participant.self,
+            configurations: config
+        )
+        let context = ModelContext(container)
+
+        let expedition = Expedition(name: "Test Expedition")
+        context.insert(expedition)
+
+        let item = ChecklistItem(title: "Apply for permits", category: .permits)
+        item.expedition = expedition
+        if expedition.checklistItems == nil {
+            expedition.checklistItems = []
+        }
+        expedition.checklistItems?.append(item)
+        context.insert(item)
+
+        try context.save()
+
+        let descriptor = FetchDescriptor<ChecklistItem>()
+        let fetched = try context.fetch(descriptor)
+
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.title, "Apply for permits")
+        XCTAssertEqual(fetched.first?.category, .permits)
+        XCTAssertNotNil(fetched.first?.expedition)
+        XCTAssertEqual(fetched.first?.expedition?.name, "Test Expedition")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ChecklistItem` SwiftData model with status tracking (pending/in-progress/completed/skipped), 8 categories, deadline support (explicit date or offset from expedition start), and participant assignment
- Add `ChecklistViewModel` with full CRUD, status toggle cycling, filtering by status/category/search, sorting, overdue/upcoming detection, and completion stats
- Add 4 checklist views: list with summary stats and overdue/upcoming sections, detail view, create/edit form with relative deadline stepper, and row view with status toggle
- Integrate into `ExpeditionDetailView` as "Pre-Departure Tasks" in the Logistics section
- Add inverse `checklistAssignments` relationship on `Participant` for CloudKit compatibility
- Add 27 unit tests covering model, enums, computed properties, and SwiftData persistence

## Test plan

- [x] `swiftlint lint --quiet` — 0 violations
- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — 212 tests pass (27 new + 185 existing), 0 failures

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)