### PR TITLE
Add group gear assignments with weight distribution

### DIFF
--- a/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
+++ b/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		ED5BF9CE473F11A025775732 /* ItineraryDayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCF1EDCF7A127F6EFDB3C9C /* ItineraryDayTests.swift */; };
 		EE3C0833CD9F39DE7F1C6DD5 /* SatelliteDeviceFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47C679F714D3C79B17C7A9 /* SatelliteDeviceFormView.swift */; };
 		F02F02E586F929B8DFA99DFC /* WeightSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7E3C130067A7AA87459DD0 /* WeightSummaryView.swift */; };
+		GG001 /* GearWeightDistributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GG101 /* GearWeightDistributionView.swift */; };
 		F232F6609543E654078AD267 /* Shelter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953CFB3C4F714B47108640E3 /* Shelter.swift */; };
 		F2761D9703DE6E1357FE12E5 /* TransportDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9067035F1696616448AB21B /* TransportDetailView.swift */; };
 		F460DB2D6299AB4D2AFD2CB3 /* ParticipantDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856BCE3A7D33E4FA6D1AFD44 /* ParticipantDetailView.swift */; };
@@ -229,6 +230,7 @@
 		8DD483224C02737F12235F86 /* GearItemTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GearItemTests.swift; sourceTree = "<group>"; };
 		8E6DF5CC7C7DBD55808FA61E /* TransportListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logistics/Transport/TransportListView.swift; sourceTree = "<group>"; };
 		8E7E3C130067A7AA87459DD0 /* WeightSummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeightSummaryView.swift; sourceTree = "<group>"; };
+		GG101 /* GearWeightDistributionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GearWeightDistributionView.swift; sourceTree = "<group>"; };
 		92318202FC80142AFC622A3E /* ShelterFormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShelterFormView.swift; sourceTree = "<group>"; };
 		9466AF824266C9E22E26D382 /* SyncStatusService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncStatusService.swift; sourceTree = "<group>"; };
 		952B6E770951CDC5A814EB29 /* ResupplyListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ../Views/Logistics/Resupply/ResupplyListView.swift; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 				C4CC970EF31F11B723572AD0 /* GearRowView.swift */,
 				B0136F567FEF4A9E645C0B0B /* GearItemFormView.swift */,
 				8E7E3C130067A7AA87459DD0 /* WeightSummaryView.swift */,
+				GG101 /* GearWeightDistributionView.swift */,
 			);
 			name = Gear;
 			path = Gear;
@@ -834,6 +837,7 @@
 				995C9B3B4C43AC5ECAFC5C0F /* GearListView.swift in Sources */,
 				A1276CA526054A3CFA3C6CFF /* GearRowView.swift in Sources */,
 				B08C0A233ADDC7301F0BE8F6 /* GearItemFormView.swift in Sources */,
+				GG001 /* GearWeightDistributionView.swift in Sources */,
 				F02F02E586F929B8DFA99DFC /* WeightSummaryView.swift in Sources */,
 				64BADD0DC57BA65EA41AFC26 /* BudgetListView.swift in Sources */,
 				BB0F4CB60B477009042ED4F3 /* BudgetRowView.swift in Sources */,

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/GearItem.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/GearItem.swift
@@ -31,6 +31,10 @@ final class GearItem {
     // Relationship - must be optional for CloudKit
     var expedition: Expedition?
 
+    // Ownership and carrier assignment
+    var ownershipType: GearOwnershipType = GearOwnershipType.personal
+    var carriedBy: Participant?
+
     init(
         name: String = "",
         category: GearCategory = .personalItems,
@@ -38,7 +42,8 @@ final class GearItem {
         descriptionOrPurpose: String = "",
         exampleProduct: String = "",
         selection: String = "",
-        quantity: Int = 1
+        quantity: Int = 1,
+        ownershipType: GearOwnershipType = .personal
     ) {
         self.id = UUID()
         self.name = name
@@ -48,6 +53,7 @@ final class GearItem {
         self.exampleProduct = exampleProduct
         self.selection = selection
         self.quantity = quantity
+        self.ownershipType = ownershipType
     }
 
     // MARK: - Computed Properties
@@ -60,6 +66,10 @@ final class GearItem {
     var totalWeight: Measurement<UnitMass>? {
         guard let grams = weightGrams else { return nil }
         return Measurement(value: grams * Double(quantity), unit: .grams)
+    }
+
+    var carriedByName: String {
+        carriedBy?.displayName ?? "Unassigned"
     }
 
     var isComplete: Bool {
@@ -124,6 +134,20 @@ enum GearCategory: String, Codable, CaseIterable {
         case .toolsFirstAidEmergency: return 10
         case .personalItems: return 11
         case .electronics: return 12
+        }
+    }
+}
+
+// MARK: - Gear Ownership Type
+
+enum GearOwnershipType: String, Codable, CaseIterable {
+    case personal = "Personal"
+    case group = "Group"
+
+    var icon: String {
+        switch self {
+        case .personal: return "person"
+        case .group: return "person.3"
         }
     }
 }

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/Participant.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/Participant.swift
@@ -42,6 +42,9 @@ final class Participant {
     @Relationship(deleteRule: .nullify, inverse: \ChecklistItem.assignedTo)
     var checklistAssignments: [ChecklistItem]?
 
+    @Relationship(deleteRule: .nullify, inverse: \GearItem.carriedBy)
+    var gearAssignments: [GearItem]?
+
     init(
         name: String = "",
         email: String = "",

--- a/ExpeditionPlanner/ExpeditionPlanner/ViewModels/GearViewModel.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ViewModels/GearViewModel.swift
@@ -9,6 +9,7 @@ enum GearSortOrder: String, CaseIterable {
     case priority = "Priority"
     case name = "Name"
     case weight = "Weight"
+    case carrier = "Carrier"
 }
 
 @Observable
@@ -22,6 +23,7 @@ final class GearViewModel {
     var searchText: String = ""
     var filterCategory: GearCategory?
     var filterPriority: GearPriority?
+    var filterOwnership: GearOwnershipType?
     var showUnpackedOnly: Bool = false
     var sortOrder: GearSortOrder = .category
 
@@ -66,6 +68,10 @@ final class GearViewModel {
                 let weight2 = item2.totalWeight?.value ?? 0
                 return weight1 > weight2
             }
+        case .carrier:
+            return items.sorted {
+                $0.carriedByName.localizedCaseInsensitiveCompare($1.carriedByName) == .orderedAscending
+            }
         }
     }
 
@@ -79,6 +85,11 @@ final class GearViewModel {
                 item.descriptionOrPurpose.localizedCaseInsensitiveContains(searchText) ||
                 item.selection.localizedCaseInsensitiveContains(searchText)
             }
+        }
+
+        // Apply ownership filter
+        if let ownership = filterOwnership {
+            items = items.filter { $0.ownershipType == ownership }
         }
 
         // Apply category filter
@@ -158,6 +169,40 @@ final class GearViewModel {
         return weights
     }
 
+    // MARK: - Group Gear & Weight Distribution
+
+    var groupItems: [GearItem] {
+        allItems.filter { $0.ownershipType == .group }
+    }
+
+    var groupWeightGrams: Double {
+        groupItems.compactMap { $0.totalWeight?.value }.reduce(0, +)
+    }
+
+    var unassignedGroupItems: [GearItem] {
+        groupItems.filter { $0.carriedBy == nil }
+    }
+
+    var unassignedGroupWeightGrams: Double {
+        unassignedGroupItems.compactMap { $0.totalWeight?.value }.reduce(0, +)
+    }
+
+    func weightForParticipant(_ participant: Participant) -> Double {
+        allItems
+            .filter { $0.carriedBy?.id == participant.id }
+            .compactMap { $0.totalWeight?.value }
+            .reduce(0, +)
+    }
+
+    var weightByParticipant: [(participant: Participant, weightGrams: Double)] {
+        let participants = expedition.participants ?? []
+        return participants.map { participant in
+            (participant: participant, weightGrams: weightForParticipant(participant))
+        }
+        .filter { $0.weightGrams > 0 }
+        .sorted { $0.weightGrams > $1.weightGrams }
+    }
+
     // MARK: - Weight Formatting
 
     func formatWeight(_ grams: Double, unit: WeightUnit) -> String {
@@ -233,6 +278,14 @@ final class GearViewModel {
         }
     }
 
+    // MARK: - Carrier Assignment
+
+    func assignCarrier(_ participant: Participant?, to item: GearItem) {
+        item.carriedBy = participant
+        logger.info("Assigned carrier '\(participant?.displayName ?? "none")' to gear '\(item.name)'")
+        save()
+    }
+
     // MARK: - Status Toggles
 
     func togglePacked(_ item: GearItem) {
@@ -266,12 +319,14 @@ final class GearViewModel {
     func clearFilters() {
         filterCategory = nil
         filterPriority = nil
+        filterOwnership = nil
         showUnpackedOnly = false
         searchText = ""
     }
 
     var hasActiveFilters: Bool {
-        filterCategory != nil || filterPriority != nil || showUnpackedOnly || !searchText.isEmpty
+        filterCategory != nil || filterPriority != nil || filterOwnership != nil
+            || showUnpackedOnly || !searchText.isEmpty
     }
 
     // MARK: - Persistence

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearItemFormView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearItemFormView.swift
@@ -32,6 +32,8 @@ struct GearItemFormView: View {
     @State private var isWeighed = false
     @State private var isInHand = false
     @State private var isPacked = false
+    @State private var ownershipType: GearOwnershipType = .personal
+    @State private var carriedByID: UUID?
 
     private var isEditing: Bool {
         if case .edit = mode { return true }
@@ -61,6 +63,9 @@ struct GearItemFormView: View {
             Form {
                 // Basic Info Section
                 basicInfoSection
+
+                // Assignment Section
+                assignmentSection
 
                 // Weight Section
                 weightSection
@@ -127,6 +132,27 @@ struct GearItemFormView: View {
                 .lineLimit(2...4)
         } header: {
             Text("Basic Info")
+        }
+    }
+
+    private var assignmentSection: some View {
+        Section {
+            Picker("Ownership", selection: $ownershipType) {
+                ForEach(GearOwnershipType.allCases, id: \.self) { type in
+                    Label(type.rawValue, systemImage: type.icon).tag(type)
+                }
+            }
+
+            if ownershipType == .group {
+                Picker("Carried By", selection: $carriedByID) {
+                    Text("Unassigned").tag(nil as UUID?)
+                    ForEach(expedition.participants ?? []) { participant in
+                        Text(participant.displayName).tag(participant.id as UUID?)
+                    }
+                }
+            }
+        } header: {
+            Text("Assignment")
         }
     }
 
@@ -289,6 +315,8 @@ struct GearItemFormView: View {
         isWeighed = item.isWeighed
         isInHand = item.isInHand
         isPacked = item.isPacked
+        ownershipType = item.ownershipType
+        carriedByID = item.carriedBy?.id
     }
 
     private func saveItem() {
@@ -314,6 +342,12 @@ struct GearItemFormView: View {
         item.isWeighed = isWeighed
         item.isInHand = isInHand
         item.isPacked = isPacked
+        item.ownershipType = ownershipType
+        if ownershipType == .group, let carriedByID {
+            item.carriedBy = (expedition.participants ?? []).first { $0.id == carriedByID }
+        } else {
+            item.carriedBy = nil
+        }
 
         dismiss()
     }

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearListView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearListView.swift
@@ -143,6 +143,15 @@ struct GearListView: View {
                 .buttonStyle(.plain)
             }
 
+            // Weight distribution link
+            if !viewModel.groupItems.isEmpty {
+                NavigationLink {
+                    GearWeightDistributionView(viewModel: viewModel)
+                } label: {
+                    Label("Weight Distribution", systemImage: "chart.bar.horizontal")
+                }
+            }
+
             // Filter indicator
             if viewModel.hasActiveFilters {
                 Section {
@@ -310,6 +319,36 @@ struct GearListView: View {
                 }
             }
 
+            // Ownership submenu
+            Menu("Ownership") {
+                Button {
+                    viewModel.filterOwnership = nil
+                } label: {
+                    Label(
+                        "All",
+                        systemImage: viewModel.filterOwnership == nil ? "checkmark" : ""
+                    )
+                }
+
+                Divider()
+
+                ForEach(GearOwnershipType.allCases, id: \.self) { ownership in
+                    Button {
+                        viewModel.filterOwnership = ownership
+                    } label: {
+                        Label {
+                            Text(ownership.rawValue)
+                        } icon: {
+                            if viewModel.filterOwnership == ownership {
+                                Image(systemName: "checkmark")
+                            } else {
+                                Image(systemName: ownership.icon)
+                            }
+                        }
+                    }
+                }
+            }
+
             Divider()
 
             // Sort order submenu
@@ -344,6 +383,10 @@ struct GearListView: View {
 
         if let priority = viewModel.filterPriority {
             parts.append(priority.rawValue)
+        }
+
+        if let ownership = viewModel.filterOwnership {
+            parts.append(ownership.rawValue)
         }
 
         if viewModel.showUnpackedOnly {

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearRowView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearRowView.swift
@@ -73,6 +73,17 @@ struct GearRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
 
+            // Carrier badge for group gear
+            if item.ownershipType == .group {
+                Label(
+                    item.carriedByName,
+                    systemImage: "person.3"
+                )
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
             // Selection if available
             if !item.selection.isEmpty {
                 Text(item.selection)

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearWeightDistributionView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Gear/GearWeightDistributionView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import SwiftData
+
+struct GearWeightDistributionView: View {
+    var viewModel: GearViewModel
+
+    @AppStorage("weightUnit")
+    private var weightUnit: WeightUnit = .kilograms
+
+    var body: some View {
+        List {
+            // Summary header
+            summarySection
+
+            // Per-participant breakdown
+            if !viewModel.weightByParticipant.isEmpty {
+                participantSection
+            }
+
+            // Unassigned group gear
+            if !viewModel.unassignedGroupItems.isEmpty {
+                unassignedSection
+            }
+        }
+        .navigationTitle("Weight Distribution")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Summary Section
+
+    private var summarySection: some View {
+        Section {
+            LabeledContent("Group Gear") {
+                Text(viewModel.formatWeight(viewModel.groupWeightGrams, unit: weightUnit))
+                    .fontWeight(.medium)
+            }
+
+            LabeledContent("Unassigned") {
+                Text(viewModel.formatWeight(viewModel.unassignedGroupWeightGrams, unit: weightUnit))
+                    .fontWeight(.medium)
+                    .foregroundStyle(viewModel.unassignedGroupItems.isEmpty ? Color.secondary : Color.orange)
+            }
+
+            LabeledContent("Group Items") {
+                Text("\(viewModel.groupItems.count)")
+            }
+        } header: {
+            Text("Overview")
+        }
+    }
+
+    // MARK: - Participant Section
+
+    private var participantSection: some View {
+        Section {
+            let maxWeight = viewModel.weightByParticipant.map(\.weightGrams).max() ?? 1
+
+            ForEach(viewModel.weightByParticipant, id: \.participant.id) { entry in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(entry.participant.displayName)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Text(viewModel.formatWeight(entry.weightGrams, unit: weightUnit))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    GeometryReader { geometry in
+                        let fraction = maxWeight > 0 ? entry.weightGrams / maxWeight : 0
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(.blue.opacity(0.7))
+                            .frame(width: geometry.size.width * fraction, height: 8)
+                    }
+                    .frame(height: 8)
+                }
+                .padding(.vertical, 4)
+            }
+        } header: {
+            Text("By Participant")
+        }
+    }
+
+    // MARK: - Unassigned Section
+
+    private var unassignedSection: some View {
+        Section {
+            ForEach(viewModel.unassignedGroupItems) { item in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.name)
+                            .font(.subheadline)
+                        Label(item.category.rawValue, systemImage: item.category.icon)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if let weight = item.totalWeight {
+                        Text(viewModel.formatWeight(weight.value, unit: weightUnit))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        } header: {
+            Text("Unassigned Group Gear")
+        } footer: {
+            Text("Assign carriers in the gear item editor.")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        GearWeightDistributionView(
+            viewModel: {
+                let expedition = Expedition(name: "Test")
+                // swiftlint:disable:next force_try
+                let container = try! ModelContainer(
+                    for: Expedition.self,
+                    configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+                )
+                return GearViewModel(
+                    expedition: expedition,
+                    modelContext: container.mainContext
+                )
+            }()
+        )
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlannerTests/GearItemTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/GearItemTests.swift
@@ -144,4 +144,95 @@ final class GearItemTests: XCTestCase {
         XCTAssertEqual(GearPriority.critical.icon, "exclamationmark.triangle.fill")
         XCTAssertEqual(GearPriority.critical.color, "red")
     }
+
+    // MARK: - Ownership Type Tests
+
+    func testDefaultOwnershipType() throws {
+        let item = GearItem(name: "Test")
+        XCTAssertEqual(item.ownershipType, .personal)
+    }
+
+    func testGroupOwnershipType() throws {
+        let item = GearItem(name: "Tent", ownershipType: .group)
+        XCTAssertEqual(item.ownershipType, .group)
+    }
+
+    func testCarriedByNameWithParticipant() throws {
+        let item = GearItem(name: "Stove")
+        let participant = Participant(name: "Alice Smith")
+        item.carriedBy = participant
+        XCTAssertEqual(item.carriedByName, "Alice Smith")
+    }
+
+    func testCarriedByNameWithoutParticipant() throws {
+        let item = GearItem(name: "Filter")
+        XCTAssertNil(item.carriedBy)
+        XCTAssertEqual(item.carriedByName, "Unassigned")
+    }
+
+    func testOwnershipTypeAllCases() throws {
+        let allCases = GearOwnershipType.allCases
+        XCTAssertEqual(allCases.count, 2)
+        XCTAssertTrue(allCases.contains(.personal))
+        XCTAssertTrue(allCases.contains(.group))
+    }
+
+    func testOwnershipTypeIcons() throws {
+        for ownership in GearOwnershipType.allCases {
+            XCTAssertFalse(ownership.icon.isEmpty)
+        }
+        XCTAssertEqual(GearOwnershipType.personal.icon, "person")
+        XCTAssertEqual(GearOwnershipType.group.icon, "person.3")
+    }
+
+    @MainActor func testGearItemWithOwnershipPersistence() throws {
+        let container = try ModelContainer(
+            for: Expedition.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+
+        let expedition = Expedition(name: "Test Expedition")
+        context.insert(expedition)
+
+        let item = GearItem(name: "Bear Canister", ownershipType: .group)
+        item.expedition = expedition
+        context.insert(item)
+
+        try context.save()
+
+        let descriptor = FetchDescriptor<GearItem>()
+        let fetched = try context.fetch(descriptor)
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.ownershipType, .group)
+        XCTAssertEqual(fetched.first?.name, "Bear Canister")
+    }
+
+    @MainActor func testGearItemCarrierAssignment() throws {
+        let container = try ModelContainer(
+            for: Expedition.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = container.mainContext
+
+        let expedition = Expedition(name: "Test Expedition")
+        context.insert(expedition)
+
+        let participant = Participant(name: "Bob Jones")
+        participant.expedition = expedition
+        context.insert(participant)
+
+        let item = GearItem(name: "Water Filter", ownershipType: .group)
+        item.expedition = expedition
+        item.carriedBy = participant
+        context.insert(item)
+
+        try context.save()
+
+        let descriptor = FetchDescriptor<GearItem>()
+        let fetched = try context.fetch(descriptor)
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.carriedBy?.name, "Bob Jones")
+        XCTAssertEqual(fetched.first?.carriedByName, "Bob Jones")
+    }
 }


### PR DESCRIPTION
## Summary
- Add `GearOwnershipType` enum (personal/group) and `carriedBy: Participant?` relationship to `GearItem` model with inverse on `Participant`
- Add `GearWeightDistributionView` showing per-participant carried weight with horizontal bar chart, group gear summary, and unassigned items list
- Add ownership picker and conditional carrier picker to gear item form, carrier badge on group gear rows, ownership filter in gear list menu, and carrier sort option

## Test plan
- [ ] Verify 220 tests pass (212 existing + 8 new ownership/carrier tests)
- [ ] SwiftLint passes with 0 violations
- [ ] Create gear items with personal and group ownership types
- [ ] Assign carriers to group gear and verify badge appears in gear list rows
- [ ] Check weight distribution view shows correct per-participant breakdown
- [ ] Filter gear list by ownership type (Personal/Group)
- [ ] Sort gear list by Carrier
- [ ] Edit existing gear items and verify ownership/carrier persists

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)