### PR TITLE
Add escape routes & bailout planning

### DIFF
--- a/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
+++ b/ExpeditionPlanner/ExpeditionPlanner.xcodeproj/project.pbxproj
@@ -145,6 +145,14 @@
 		CL005 /* ChecklistFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL105 /* ChecklistFormView.swift */; };
 		CL006 /* ChecklistRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL106 /* ChecklistRowView.swift */; };
 		CLT01 /* ChecklistItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CLT101 /* ChecklistItemTests.swift */; };
+		ER001 /* EscapeRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER101 /* EscapeRoute.swift */; };
+		ER002 /* EscapeRouteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER102 /* EscapeRouteViewModel.swift */; };
+		ER003 /* EscapeRouteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER103 /* EscapeRouteListView.swift */; };
+		ER004 /* EscapeRouteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER104 /* EscapeRouteDetailView.swift */; };
+		ER005 /* EscapeRouteFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER105 /* EscapeRouteFormView.swift */; };
+		ER006 /* EscapeRouteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER106 /* EscapeRouteRowView.swift */; };
+		ER007 /* EscapeWaypointFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ER107 /* EscapeWaypointFormView.swift */; };
+		ERT01 /* EscapeRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ERT101 /* EscapeRouteTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -301,6 +309,14 @@
 		CL105 /* ChecklistFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistFormView.swift; sourceTree = "<group>"; };
 		CL106 /* ChecklistRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistRowView.swift; sourceTree = "<group>"; };
 		CLT101 /* ChecklistItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistItemTests.swift; sourceTree = "<group>"; };
+		ER101 /* EscapeRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRoute.swift; sourceTree = "<group>"; };
+		ER102 /* EscapeRouteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteViewModel.swift; sourceTree = "<group>"; };
+		ER103 /* EscapeRouteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteListView.swift; sourceTree = "<group>"; };
+		ER104 /* EscapeRouteDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteDetailView.swift; sourceTree = "<group>"; };
+		ER105 /* EscapeRouteFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteFormView.swift; sourceTree = "<group>"; };
+		ER106 /* EscapeRouteRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteRowView.swift; sourceTree = "<group>"; };
+		ER107 /* EscapeWaypointFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeWaypointFormView.swift; sourceTree = "<group>"; };
+		ERT101 /* EscapeRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeRouteTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -385,6 +401,7 @@
 				71203CF5DE80A45D4129DE9C /* Accommodation.swift */,
 				0418909D68337C695811A94A /* SatelliteDevice.swift */,
 				CL101 /* ChecklistItem.swift */,
+				ER101 /* EscapeRoute.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -472,6 +489,11 @@
 				3F754F8CC551CCB5BBEDB3F1 /* RiskAssessmentFormView.swift */,
 				D4FC6A206E66F64BCEF9EB32 /* RiskMatrixView.swift */,
 				7917753DDED431080D16D270 /* EmergencyContactsView.swift */,
+				ER103 /* EscapeRouteListView.swift */,
+				ER104 /* EscapeRouteDetailView.swift */,
+				ER105 /* EscapeRouteFormView.swift */,
+				ER106 /* EscapeRouteRowView.swift */,
+				ER107 /* EscapeWaypointFormView.swift */,
 			);
 			name = Safety;
 			path = Safety;
@@ -612,6 +634,7 @@
 				RMT102 /* GPXServiceTests.swift */,
 				RMT103 /* RouteServiceTests.swift */,
 				CLT101 /* ChecklistItemTests.swift */,
+				ERT101 /* EscapeRouteTests.swift */,
 			);
 			path = ExpeditionPlannerTests;
 			sourceTree = "<group>";
@@ -663,6 +686,7 @@
 				8C6E4BDE40E727E8662D2B36 /* AccommodationViewModel.swift */,
 				782368A25AAF9F42F3ABE1F2 /* SatelliteDeviceViewModel.swift */,
 				CL102 /* ChecklistViewModel.swift */,
+				ER102 /* EscapeRouteViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -893,6 +917,13 @@
 				CL004 /* ChecklistDetailView.swift in Sources */,
 				CL005 /* ChecklistFormView.swift in Sources */,
 				CL006 /* ChecklistRowView.swift in Sources */,
+				ER001 /* EscapeRoute.swift in Sources */,
+				ER002 /* EscapeRouteViewModel.swift in Sources */,
+				ER003 /* EscapeRouteListView.swift in Sources */,
+				ER004 /* EscapeRouteDetailView.swift in Sources */,
+				ER005 /* EscapeRouteFormView.swift in Sources */,
+				ER006 /* EscapeRouteRowView.swift in Sources */,
+				ER007 /* EscapeWaypointFormView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -914,6 +945,7 @@
 				RMT02 /* GPXServiceTests.swift in Sources */,
 				RMT03 /* RouteServiceTests.swift in Sources */,
 				CLT01 /* ChecklistItemTests.swift in Sources */,
+				ERT01 /* EscapeRouteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExpeditionPlanner/ExpeditionPlanner/ChakiApp.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ChakiApp.swift
@@ -32,7 +32,9 @@ struct ChakiApp: App {
                 InsurancePolicy.self,
                 Shelter.self,
                 HistoricalClimate.self,
-                ChecklistItem.self
+                ChecklistItem.self,
+                EscapeRoute.self,
+                EscapeWaypoint.self
             ])
 
             let cloudKitDatabase: ModelConfiguration.CloudKitDatabase

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/EscapeRoute.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/EscapeRoute.swift
@@ -1,0 +1,247 @@
+import Foundation
+import SwiftData
+import CoreLocation
+
+// MARK: - Escape Route Type
+
+enum EscapeRouteType: String, Codable, CaseIterable {
+    case primary = "Primary"
+    case alternate = "Alternate"
+    case emergencyOnly = "Emergency Only"
+
+    var icon: String {
+        switch self {
+        case .primary: return "arrow.uturn.backward.circle.fill"
+        case .alternate: return "arrow.uturn.backward.circle"
+        case .emergencyOnly: return "exclamationmark.arrow.circlepath"
+        }
+    }
+
+    var color: String {
+        switch self {
+        case .primary: return "green"
+        case .alternate: return "orange"
+        case .emergencyOnly: return "red"
+        }
+    }
+
+    var sortOrder: Int {
+        switch self {
+        case .primary: return 0
+        case .alternate: return 1
+        case .emergencyOnly: return 2
+        }
+    }
+}
+
+// MARK: - Escape Destination Type
+
+enum EscapeDestinationType: String, Codable, CaseIterable {
+    case trailhead = "Trailhead"
+    case road = "Road"
+    case airstrip = "Airstrip"
+    case town = "Town"
+    case ranger = "Ranger Station"
+    case hospital = "Hospital"
+    case shelter = "Shelter"
+    case other = "Other"
+
+    var icon: String {
+        switch self {
+        case .trailhead: return "figure.hiking"
+        case .road: return "road.lanes"
+        case .airstrip: return "airplane"
+        case .town: return "building.2"
+        case .ranger: return "shield.checkered"
+        case .hospital: return "cross.case"
+        case .shelter: return "house.fill"
+        case .other: return "mappin.circle"
+        }
+    }
+}
+
+// MARK: - Difficulty Rating
+
+enum DifficultyRating: String, Codable, CaseIterable {
+    case easy = "Easy"
+    case moderate = "Moderate"
+    case strenuous = "Strenuous"
+    case technical = "Technical"
+    case extreme = "Extreme"
+
+    var icon: String {
+        switch self {
+        case .easy: return "figure.walk"
+        case .moderate: return "figure.hiking"
+        case .strenuous: return "figure.climbing"
+        case .technical: return "figure.climbing"
+        case .extreme: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    var color: String {
+        switch self {
+        case .easy: return "green"
+        case .moderate: return "blue"
+        case .strenuous: return "orange"
+        case .technical: return "red"
+        case .extreme: return "purple"
+        }
+    }
+}
+
+// MARK: - Escape Route Model
+
+@Model
+final class EscapeRoute {
+    var id: UUID = UUID()
+    var name: String = ""
+    var routeDescription: String = ""
+    var routeType: EscapeRouteType = EscapeRouteType.primary
+
+    // Segment link
+    var startDayNumber: Int?
+    var endDayNumber: Int?
+    var segmentName: String = ""
+
+    // Metrics
+    var distanceMeters: Double?
+    var estimatedHours: Double?
+    var elevationGainMeters: Double?
+    var elevationLossMeters: Double?
+
+    // Terrain
+    var terrainDescription: String = ""
+    var hazards: String = ""
+    var requiredGear: String = ""
+    var seasonalNotes: String = ""
+    var difficultyRating: DifficultyRating = DifficultyRating.moderate
+
+    // Destination
+    var destinationType: EscapeDestinationType = EscapeDestinationType.trailhead
+    var destinationName: String = ""
+    var destinationLatitude: Double?
+    var destinationLongitude: Double?
+
+    // Medical
+    var nearestMedicalFacility: String = ""
+    var medicalFacilityDistance: String = ""
+    var communicationNotes: String = ""
+
+    // Status
+    var isVerified: Bool = false
+    var lastVerifiedDate: Date?
+    var notes: String = ""
+
+    // Relationships
+    var expedition: Expedition?
+
+    @Relationship(deleteRule: .cascade, inverse: \EscapeWaypoint.escapeRoute)
+    var waypoints: [EscapeWaypoint]?
+
+    init(
+        name: String = "",
+        routeType: EscapeRouteType = .primary,
+        segmentName: String = ""
+    ) {
+        self.id = UUID()
+        self.name = name
+        self.routeType = routeType
+        self.segmentName = segmentName
+    }
+
+    // MARK: - Computed Properties
+
+    var distance: Measurement<UnitLength>? {
+        guard let meters = distanceMeters else { return nil }
+        return Measurement(value: meters, unit: .meters)
+    }
+
+    var elevationGain: Measurement<UnitLength>? {
+        guard let meters = elevationGainMeters else { return nil }
+        return Measurement(value: meters, unit: .meters)
+    }
+
+    var elevationLoss: Measurement<UnitLength>? {
+        guard let meters = elevationLossMeters else { return nil }
+        return Measurement(value: meters, unit: .meters)
+    }
+
+    var destinationCoordinate: CLLocationCoordinate2D? {
+        guard let lat = destinationLatitude, let lon = destinationLongitude else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    var formattedEstimatedTime: String? {
+        guard let hours = estimatedHours else { return nil }
+        let wholeHours = Int(hours)
+        let minutes = Int((hours - Double(wholeHours)) * 60)
+        if wholeHours == 0 {
+            return "\(minutes)m"
+        } else if minutes == 0 {
+            return "\(wholeHours)h"
+        }
+        return "\(wholeHours)h \(minutes)m"
+    }
+
+    var sortedWaypoints: [EscapeWaypoint] {
+        (waypoints ?? []).sorted { $0.orderIndex < $1.orderIndex }
+    }
+
+    var waypointCount: Int {
+        (waypoints ?? []).count
+    }
+
+    var dayRangeDescription: String? {
+        guard let start = startDayNumber else { return nil }
+        guard let end = endDayNumber else { return "Day \(start)" }
+        if start == end { return "Day \(start)" }
+        return "Days \(start)-\(end)"
+    }
+
+    var hasCoordinates: Bool {
+        destinationLatitude != nil && destinationLongitude != nil
+    }
+}
+
+// MARK: - Escape Waypoint Model
+
+@Model
+final class EscapeWaypoint {
+    var id: UUID = UUID()
+    var name: String = ""
+    var orderIndex: Int = 0
+    var latitude: Double?
+    var longitude: Double?
+    var elevationMeters: Double?
+    var waypointDescription: String = ""
+    var hazards: String = ""
+    var notes: String = ""
+
+    var escapeRoute: EscapeRoute?
+
+    init(
+        name: String = "",
+        orderIndex: Int = 0
+    ) {
+        self.id = UUID()
+        self.name = name
+        self.orderIndex = orderIndex
+    }
+
+    // MARK: - Computed Properties
+
+    var coordinate: CLLocationCoordinate2D? {
+        guard let lat = latitude, let lon = longitude else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    var elevation: Measurement<UnitLength>? {
+        guard let meters = elevationMeters else { return nil }
+        return Measurement(value: meters, unit: .meters)
+    }
+
+    var hasCoordinates: Bool {
+        latitude != nil && longitude != nil
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Models/Expedition.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Models/Expedition.swift
@@ -54,6 +54,9 @@ final class Expedition {
     @Relationship(deleteRule: .cascade, inverse: \ChecklistItem.expedition)
     var checklistItems: [ChecklistItem]?
 
+    @Relationship(deleteRule: .cascade, inverse: \EscapeRoute.expedition)
+    var escapeRoutes: [EscapeRoute]?
+
     init(
         name: String = "",
         expeditionDescription: String = "",

--- a/ExpeditionPlanner/ExpeditionPlanner/ViewModels/EscapeRouteViewModel.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/ViewModels/EscapeRouteViewModel.swift
@@ -1,0 +1,193 @@
+import Foundation
+import SwiftData
+import OSLog
+
+private let logger = Logger(subsystem: "com.chaki.app", category: "EscapeRouteViewModel")
+
+enum EscapeRouteSortOrder: String, CaseIterable {
+    case routeType = "Route Type"
+    case segment = "Segment"
+    case name = "Name"
+    case distance = "Distance"
+}
+
+@Observable
+final class EscapeRouteViewModel {
+    private var modelContext: ModelContext
+
+    var routes: [EscapeRoute] = []
+    var searchText: String = ""
+    var filterRouteType: EscapeRouteType?
+    var showUnverifiedOnly: Bool = false
+    var sortOrder: EscapeRouteSortOrder = .routeType
+    var errorMessage: String?
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Load Data
+
+    func loadRoutes(for expedition: Expedition) {
+        let allRoutes = expedition.escapeRoutes ?? []
+
+        var filtered = allRoutes
+
+        // Apply search filter
+        if !searchText.isEmpty {
+            filtered = filtered.filter { route in
+                route.name.localizedCaseInsensitiveContains(searchText) ||
+                route.routeDescription.localizedCaseInsensitiveContains(searchText) ||
+                route.destinationName.localizedCaseInsensitiveContains(searchText) ||
+                route.segmentName.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        // Apply route type filter
+        if let routeType = filterRouteType {
+            filtered = filtered.filter { $0.routeType == routeType }
+        }
+
+        // Apply unverified filter
+        if showUnverifiedOnly {
+            filtered = filtered.filter { !$0.isVerified }
+        }
+
+        // Sort
+        switch sortOrder {
+        case .routeType:
+            routes = filtered.sorted { r1, r2 in
+                if r1.routeType.sortOrder != r2.routeType.sortOrder {
+                    return r1.routeType.sortOrder < r2.routeType.sortOrder
+                }
+                return r1.name < r2.name
+            }
+        case .segment:
+            routes = filtered.sorted { r1, r2 in
+                let s1 = r1.startDayNumber ?? Int.max
+                let s2 = r2.startDayNumber ?? Int.max
+                if s1 != s2 { return s1 < s2 }
+                return r1.name < r2.name
+            }
+        case .name:
+            routes = filtered.sorted { $0.name < $1.name }
+        case .distance:
+            routes = filtered.sorted { r1, r2 in
+                let d1 = r1.distanceMeters ?? Double.infinity
+                let d2 = r2.distanceMeters ?? Double.infinity
+                return d1 < d2
+            }
+        }
+    }
+
+    // MARK: - CRUD Operations
+
+    func addRoute(_ route: EscapeRoute, to expedition: Expedition) {
+        route.expedition = expedition
+        if expedition.escapeRoutes == nil {
+            expedition.escapeRoutes = []
+        }
+        expedition.escapeRoutes?.append(route)
+        modelContext.insert(route)
+
+        logger.info("Added escape route '\(route.name)' to expedition")
+        saveContext()
+        loadRoutes(for: expedition)
+    }
+
+    func deleteRoute(_ route: EscapeRoute, from expedition: Expedition) {
+        let name = route.name
+        expedition.escapeRoutes?.removeAll { $0.id == route.id }
+        modelContext.delete(route)
+
+        logger.info("Deleted escape route '\(name)' from expedition")
+        saveContext()
+        loadRoutes(for: expedition)
+    }
+
+    func updateRoute(_ route: EscapeRoute, in expedition: Expedition) {
+        logger.debug("Updated escape route '\(route.name)'")
+        saveContext()
+        loadRoutes(for: expedition)
+    }
+
+    // MARK: - Waypoint CRUD
+
+    func addWaypoint(_ waypoint: EscapeWaypoint, to route: EscapeRoute) {
+        waypoint.escapeRoute = route
+        if route.waypoints == nil {
+            route.waypoints = []
+        }
+        route.waypoints?.append(waypoint)
+        modelContext.insert(waypoint)
+
+        logger.info("Added waypoint '\(waypoint.name)' to escape route '\(route.name)'")
+        saveContext()
+    }
+
+    func deleteWaypoint(_ waypoint: EscapeWaypoint, from route: EscapeRoute) {
+        let name = waypoint.name
+        route.waypoints?.removeAll { $0.id == waypoint.id }
+        modelContext.delete(waypoint)
+
+        logger.info("Deleted waypoint '\(name)' from escape route '\(route.name)'")
+        saveContext()
+    }
+
+    func reorderWaypoints(_ waypoints: [EscapeWaypoint]) {
+        for (index, waypoint) in waypoints.enumerated() {
+            waypoint.orderIndex = index
+        }
+        saveContext()
+    }
+
+    // MARK: - Computed Properties
+
+    var primaryRoutes: [EscapeRoute] {
+        routes.filter { $0.routeType == .primary }
+    }
+
+    var unverifiedCount: Int {
+        routes.filter { !$0.isVerified }.count
+    }
+
+    var routeTypeCounts: [EscapeRouteType: Int] {
+        var counts: [EscapeRouteType: Int] = [:]
+        for route in routes {
+            counts[route.routeType, default: 0] += 1
+        }
+        return counts
+    }
+
+    var groupedByType: [(routeType: EscapeRouteType, routes: [EscapeRoute])] {
+        let grouped = Dictionary(grouping: routes) { $0.routeType }
+        return EscapeRouteType.allCases.compactMap { routeType in
+            guard let list = grouped[routeType], !list.isEmpty else { return nil }
+            return (routeType: routeType, routes: list)
+        }
+    }
+
+    // MARK: - Filtering
+
+    func clearFilters() {
+        searchText = ""
+        filterRouteType = nil
+        showUnverifiedOnly = false
+    }
+
+    var hasActiveFilters: Bool {
+        filterRouteType != nil || showUnverifiedOnly || !searchText.isEmpty
+    }
+
+    // MARK: - Private
+
+    private func saveContext() {
+        do {
+            try modelContext.save()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Failed to save: \(error.localizedDescription)"
+            logger.error("Failed to save escape route changes: \(error.localizedDescription)")
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Expeditions/ExpeditionDetailView.swift
@@ -185,6 +185,15 @@ struct ExpeditionDetailView: View {
                         detail: insuranceDetail
                     )
                 }
+
+                NavigationLink(value: ExpeditionSection.escapeRoutes) {
+                    SectionRow(
+                        title: "Escape Routes",
+                        icon: "arrow.uturn.backward.circle",
+                        color: .orange,
+                        detail: escapeRoutesDetail
+                    )
+                }
             } header: {
                 Text("Safety")
             }
@@ -297,6 +306,14 @@ struct ExpeditionDetailView: View {
         return "\(done)/\(items.count) done"
     }
 
+    private var escapeRoutesDetail: String {
+        let routes = expedition.escapeRoutes ?? []
+        if routes.isEmpty { return "No routes" }
+        let unverified = routes.filter { !$0.isVerified }.count
+        if unverified > 0 { return "\(routes.count) routes, \(unverified) unverified" }
+        return "\(routes.count) routes"
+    }
+
     private var satelliteDevicesDetail: String {
         let count = (expedition.satelliteDevices ?? []).count
         if count == 0 {
@@ -344,6 +361,8 @@ struct ExpeditionDetailView: View {
             EmergencyContactsView(expedition: expedition)
         case .insurance:
             InsuranceListView(expedition: expedition)
+        case .escapeRoutes:
+            EscapeRouteListView(expedition: expedition)
         case .shelters:
             ShelterListView()
         }
@@ -371,6 +390,7 @@ enum ExpeditionSection: Hashable {
     case safety
     case emergencyContacts
     case insurance
+    case escapeRoutes
 }
 
 // MARK: - Section Row

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteDetailView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteDetailView.swift
@@ -1,0 +1,395 @@
+import SwiftUI
+import SwiftData
+
+struct EscapeRouteDetailView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let route: EscapeRoute
+    let expedition: Expedition
+    var viewModel: EscapeRouteViewModel
+
+    @State private var showingEditSheet = false
+    @State private var showingDeleteAlert = false
+
+    var body: some View {
+        List {
+            // Header
+            Section {
+                headerView
+            }
+
+            // Route Metrics
+            Section {
+                metricsSection
+            } header: {
+                Text("Route Metrics")
+            }
+
+            // Terrain & Conditions
+            if hasTerrainInfo {
+                Section {
+                    terrainSection
+                } header: {
+                    Label("Terrain & Conditions", systemImage: "mountain.2")
+                }
+            }
+
+            // Destination
+            Section {
+                destinationSection
+            } header: {
+                Label("Destination", systemImage: route.destinationType.icon)
+            }
+
+            // Waypoints
+            if route.waypointCount > 0 {
+                Section {
+                    waypointsSection
+                } header: {
+                    Text("Waypoints (\(route.waypointCount))")
+                }
+            }
+
+            // Medical & Communication
+            if hasMedicalInfo {
+                Section {
+                    medicalSection
+                } header: {
+                    Label("Medical & Communication", systemImage: "cross.case")
+                }
+            }
+
+            // Seasonal Notes
+            if !route.seasonalNotes.isEmpty {
+                Section {
+                    Text(route.seasonalNotes)
+                } header: {
+                    Text("Seasonal Notes")
+                }
+            }
+
+            // Description
+            if !route.routeDescription.isEmpty {
+                Section {
+                    Text(route.routeDescription)
+                } header: {
+                    Text("Description")
+                }
+            }
+
+            // Notes
+            if !route.notes.isEmpty {
+                Section {
+                    Text(route.notes)
+                } header: {
+                    Text("Notes")
+                }
+            }
+
+            // Status
+            Section {
+                statusSection
+            } header: {
+                Text("Status")
+            }
+
+            // Actions
+            Section {
+                Button(role: .destructive) {
+                    showingDeleteAlert = true
+                } label: {
+                    Label("Delete Escape Route", systemImage: "trash")
+                }
+            }
+        }
+        .navigationTitle("Route Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Edit") {
+                    showingEditSheet = true
+                }
+            }
+
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") {
+                    dismiss()
+                }
+            }
+        }
+        .sheet(isPresented: $showingEditSheet) {
+            NavigationStack {
+                EscapeRouteFormView(
+                    mode: .edit(route),
+                    expedition: expedition,
+                    viewModel: viewModel
+                )
+            }
+        }
+        .alert("Delete Escape Route?", isPresented: $showingDeleteAlert) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                viewModel.deleteRoute(route, from: expedition)
+                dismiss()
+            }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        HStack(spacing: 16) {
+            VStack {
+                Image(systemName: route.routeType.icon)
+                    .font(.title)
+                    .foregroundStyle(colorForType)
+            }
+            .frame(width: 60, height: 60)
+            .background(colorForType.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(route.name)
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                if let dayRange = route.dayRangeDescription {
+                    Text(dayRange)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(route.routeType.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(colorForType.opacity(0.2))
+                    .foregroundStyle(colorForType)
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
+    // MARK: - Metrics
+
+    private var metricsSection: some View {
+        VStack(spacing: 8) {
+            if let distance = route.distance {
+                LabeledContent("Distance") {
+                    Text(formatDistance(distance))
+                }
+            }
+
+            if let time = route.formattedEstimatedTime {
+                LabeledContent("Estimated Time", value: time)
+            }
+
+            if let gain = route.elevationGain {
+                LabeledContent("Elevation Gain") {
+                    Text(formatElevation(gain))
+                }
+            }
+
+            if let loss = route.elevationLoss {
+                LabeledContent("Elevation Loss") {
+                    Text(formatElevation(loss))
+                }
+            }
+
+            LabeledContent("Difficulty") {
+                HStack(spacing: 4) {
+                    Image(systemName: route.difficultyRating.icon)
+                        .foregroundStyle(colorForDifficulty)
+                    Text(route.difficultyRating.rawValue)
+                }
+            }
+        }
+    }
+
+    // MARK: - Terrain
+
+    private var hasTerrainInfo: Bool {
+        !route.terrainDescription.isEmpty || !route.hazards.isEmpty || !route.requiredGear.isEmpty
+    }
+
+    private var terrainSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !route.terrainDescription.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Terrain")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(route.terrainDescription)
+                }
+            }
+
+            if !route.hazards.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Hazards")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(route.hazards)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            if !route.requiredGear.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Required Gear")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(route.requiredGear)
+                }
+            }
+        }
+    }
+
+    // MARK: - Destination
+
+    private var destinationSection: some View {
+        VStack(spacing: 8) {
+            LabeledContent("Type") {
+                Label(route.destinationType.rawValue, systemImage: route.destinationType.icon)
+            }
+
+            if !route.destinationName.isEmpty {
+                LabeledContent("Name", value: route.destinationName)
+            }
+
+            if route.hasCoordinates {
+                LabeledContent("Coordinates") {
+                    if let lat = route.destinationLatitude, let lon = route.destinationLongitude {
+                        Text(String(format: "%.4f, %.4f", lat, lon))
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Waypoints
+
+    private var waypointsSection: some View {
+        ForEach(route.sortedWaypoints) { waypoint in
+            HStack(spacing: 12) {
+                Text("\(waypoint.orderIndex + 1)")
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .frame(width: 24, height: 24)
+                    .background(Color.blue.opacity(0.1))
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(waypoint.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+
+                    if !waypoint.waypointDescription.isEmpty {
+                        Text(waypoint.waypointDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer()
+
+                if let elevation = waypoint.elevation {
+                    Text(formatElevation(elevation))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Medical
+
+    private var hasMedicalInfo: Bool {
+        !route.nearestMedicalFacility.isEmpty ||
+        !route.medicalFacilityDistance.isEmpty ||
+        !route.communicationNotes.isEmpty
+    }
+
+    private var medicalSection: some View {
+        VStack(spacing: 8) {
+            if !route.nearestMedicalFacility.isEmpty {
+                LabeledContent("Nearest Facility", value: route.nearestMedicalFacility)
+            }
+
+            if !route.medicalFacilityDistance.isEmpty {
+                LabeledContent("Distance", value: route.medicalFacilityDistance)
+            }
+
+            if !route.communicationNotes.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Communication")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(route.communicationNotes)
+                }
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    private var statusSection: some View {
+        VStack(spacing: 12) {
+            Toggle("Verified", isOn: Binding(
+                get: { route.isVerified },
+                set: { newValue in
+                    route.isVerified = newValue
+                    if newValue { route.lastVerifiedDate = Date() }
+                    viewModel.updateRoute(route, in: expedition)
+                }
+            ))
+
+            if let verifiedDate = route.lastVerifiedDate {
+                LabeledContent("Last Verified") {
+                    Text(verifiedDate.formatted(date: .abbreviated, time: .omitted))
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var colorForType: Color {
+        switch route.routeType.color {
+        case "green": return .green
+        case "orange": return .orange
+        case "red": return .red
+        default: return .secondary
+        }
+    }
+
+    private var colorForDifficulty: Color {
+        switch route.difficultyRating.color {
+        case "green": return .green
+        case "blue": return .blue
+        case "orange": return .orange
+        case "red": return .red
+        case "purple": return .purple
+        default: return .secondary
+        }
+    }
+
+    private func formatDistance(_ distance: Measurement<UnitLength>) -> String {
+        let km = distance.converted(to: .kilometers)
+        if km.value < 1 {
+            let meters = distance.converted(to: .meters)
+            return String(format: "%.0f m", meters.value)
+        }
+        return String(format: "%.1f km", km.value)
+    }
+
+    private func formatElevation(_ elevation: Measurement<UnitLength>) -> String {
+        let meters = elevation.converted(to: .meters)
+        return String(format: "%.0f m", meters.value)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteFormView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteFormView.swift
@@ -1,0 +1,424 @@
+import SwiftUI
+import SwiftData
+
+enum EscapeRouteFormMode {
+    case create
+    case edit(EscapeRoute)
+}
+
+struct EscapeRouteFormView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let mode: EscapeRouteFormMode
+    let expedition: Expedition
+    var viewModel: EscapeRouteViewModel
+
+    // Form fields
+    @State private var name: String = ""
+    @State private var routeType: EscapeRouteType = .primary
+    @State private var routeDescription: String = ""
+
+    @State private var startDayText: String = ""
+    @State private var endDayText: String = ""
+    @State private var segmentName: String = ""
+
+    @State private var distanceText: String = ""
+    @State private var estimatedHoursText: String = ""
+    @State private var elevationGainText: String = ""
+    @State private var elevationLossText: String = ""
+    @State private var difficultyRating: DifficultyRating = .moderate
+
+    @State private var terrainDescription: String = ""
+    @State private var hazards: String = ""
+    @State private var requiredGear: String = ""
+    @State private var seasonalNotes: String = ""
+
+    @State private var destinationType: EscapeDestinationType = .trailhead
+    @State private var destinationName: String = ""
+    @State private var destLatText: String = ""
+    @State private var destLonText: String = ""
+
+    @State private var nearestMedicalFacility: String = ""
+    @State private var medicalFacilityDistance: String = ""
+    @State private var communicationNotes: String = ""
+
+    @State private var isVerified: Bool = false
+    @State private var notes: String = ""
+
+    @State private var showingWaypointSheet = false
+    @State private var editingWaypoint: EscapeWaypoint?
+
+    private var isEditing: Bool {
+        if case .edit = mode { return true }
+        return false
+    }
+
+    private var existingRoute: EscapeRoute? {
+        if case .edit(let route) = mode {
+            return route
+        }
+        return nil
+    }
+
+    var body: some View {
+        Form {
+            routeInfoSection
+            segmentSection
+            metricsSection
+            terrainSection
+            destinationSection
+            medicalSection
+
+            if isEditing, let route = existingRoute {
+                waypointsSection(route: route)
+            }
+
+            statusSection
+            notesSection
+        }
+        .navigationTitle(isEditing ? "Edit Escape Route" : "New Escape Route")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    dismiss()
+                }
+            }
+
+            ToolbarItem(placement: .confirmationAction) {
+                Button(isEditing ? "Save" : "Add") {
+                    saveRoute()
+                }
+                .disabled(name.isEmpty)
+            }
+        }
+        .sheet(isPresented: $showingWaypointSheet) {
+            NavigationStack {
+                EscapeWaypointFormView(
+                    mode: editingWaypoint.map { .edit($0) } ?? .create,
+                    onSave: { waypoint in
+                        if let route = existingRoute, editingWaypoint == nil {
+                            waypoint.orderIndex = route.waypointCount
+                            viewModel.addWaypoint(waypoint, to: route)
+                        }
+                        editingWaypoint = nil
+                    }
+                )
+            }
+        }
+        .onAppear {
+            loadExistingData()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var routeInfoSection: some View {
+        Section {
+            TextField("Route Name", text: $name)
+
+            Picker("Route Type", selection: $routeType) {
+                ForEach(EscapeRouteType.allCases, id: \.self) { type in
+                    Label(type.rawValue, systemImage: type.icon)
+                        .tag(type)
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Text("Description")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $routeDescription)
+                    .frame(minHeight: 60)
+            }
+        } header: {
+            Text("Route Info")
+        }
+    }
+
+    private var segmentSection: some View {
+        Section {
+            TextField("Start Day", text: $startDayText)
+                .keyboardType(.numberPad)
+
+            TextField("End Day", text: $endDayText)
+                .keyboardType(.numberPad)
+
+            TextField("Segment Name", text: $segmentName)
+        } header: {
+            Text("Itinerary Segment")
+        } footer: {
+            Text("Link this escape route to specific days in your itinerary.")
+        }
+    }
+
+    private var metricsSection: some View {
+        Section {
+            TextField("Distance (meters)", text: $distanceText)
+                .keyboardType(.decimalPad)
+
+            TextField("Estimated Hours", text: $estimatedHoursText)
+                .keyboardType(.decimalPad)
+
+            TextField("Elevation Gain (meters)", text: $elevationGainText)
+                .keyboardType(.decimalPad)
+
+            TextField("Elevation Loss (meters)", text: $elevationLossText)
+                .keyboardType(.decimalPad)
+
+            Picker("Difficulty", selection: $difficultyRating) {
+                ForEach(DifficultyRating.allCases, id: \.self) { rating in
+                    Text(rating.rawValue).tag(rating)
+                }
+            }
+        } header: {
+            Text("Route Metrics")
+        }
+    }
+
+    private var terrainSection: some View {
+        Section {
+            VStack(alignment: .leading) {
+                Text("Terrain Description")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $terrainDescription)
+                    .frame(minHeight: 60)
+            }
+
+            VStack(alignment: .leading) {
+                Text("Hazards")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $hazards)
+                    .frame(minHeight: 60)
+            }
+
+            VStack(alignment: .leading) {
+                Text("Required Gear")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $requiredGear)
+                    .frame(minHeight: 60)
+            }
+
+            VStack(alignment: .leading) {
+                Text("Seasonal Notes")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $seasonalNotes)
+                    .frame(minHeight: 40)
+            }
+        } header: {
+            Text("Terrain & Conditions")
+        }
+    }
+
+    private var destinationSection: some View {
+        Section {
+            Picker("Destination Type", selection: $destinationType) {
+                ForEach(EscapeDestinationType.allCases, id: \.self) { type in
+                    Label(type.rawValue, systemImage: type.icon)
+                        .tag(type)
+                }
+            }
+
+            TextField("Destination Name", text: $destinationName)
+
+            TextField("Latitude", text: $destLatText)
+                .keyboardType(.decimalPad)
+
+            TextField("Longitude", text: $destLonText)
+                .keyboardType(.decimalPad)
+        } header: {
+            Text("Destination")
+        }
+    }
+
+    private var medicalSection: some View {
+        Section {
+            TextField("Nearest Medical Facility", text: $nearestMedicalFacility)
+            TextField("Distance to Medical", text: $medicalFacilityDistance)
+
+            VStack(alignment: .leading) {
+                Text("Communication Notes")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $communicationNotes)
+                    .frame(minHeight: 60)
+            }
+        } header: {
+            Text("Medical & Communication")
+        }
+    }
+
+    private func waypointsSection(route: EscapeRoute) -> some View {
+        Section {
+            ForEach(route.sortedWaypoints) { waypoint in
+                HStack {
+                    Text("\(waypoint.orderIndex + 1).")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24)
+                    Text(waypoint.name)
+                    Spacer()
+                    if waypoint.hasCoordinates {
+                        Image(systemName: "mappin.circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    editingWaypoint = waypoint
+                    showingWaypointSheet = true
+                }
+            }
+            .onDelete { indexSet in
+                deleteWaypoints(at: indexSet, from: route)
+            }
+
+            Button {
+                editingWaypoint = nil
+                showingWaypointSheet = true
+            } label: {
+                Label("Add Waypoint", systemImage: "plus.circle")
+            }
+        } header: {
+            Text("Waypoints (\(route.waypointCount))")
+        }
+    }
+
+    private var statusSection: some View {
+        Section {
+            Toggle("Verified", isOn: $isVerified)
+        } header: {
+            Text("Status")
+        } footer: {
+            Text("Mark as verified once the route has been confirmed.")
+        }
+    }
+
+    private var notesSection: some View {
+        Section {
+            VStack(alignment: .leading) {
+                Text("Notes")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $notes)
+                    .frame(minHeight: 60)
+            }
+        } header: {
+            Text("Notes")
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadExistingData() {
+        guard let route = existingRoute else { return }
+
+        name = route.name
+        routeType = route.routeType
+        routeDescription = route.routeDescription
+
+        if let start = route.startDayNumber { startDayText = String(start) }
+        if let end = route.endDayNumber { endDayText = String(end) }
+        segmentName = route.segmentName
+
+        if let dist = route.distanceMeters { distanceText = String(dist) }
+        if let hours = route.estimatedHours { estimatedHoursText = String(hours) }
+        if let gain = route.elevationGainMeters { elevationGainText = String(gain) }
+        if let loss = route.elevationLossMeters { elevationLossText = String(loss) }
+        difficultyRating = route.difficultyRating
+
+        terrainDescription = route.terrainDescription
+        hazards = route.hazards
+        requiredGear = route.requiredGear
+        seasonalNotes = route.seasonalNotes
+
+        destinationType = route.destinationType
+        destinationName = route.destinationName
+        if let lat = route.destinationLatitude { destLatText = String(lat) }
+        if let lon = route.destinationLongitude { destLonText = String(lon) }
+
+        nearestMedicalFacility = route.nearestMedicalFacility
+        medicalFacilityDistance = route.medicalFacilityDistance
+        communicationNotes = route.communicationNotes
+
+        isVerified = route.isVerified
+        notes = route.notes
+    }
+
+    // MARK: - Save
+
+    private func saveRoute() {
+        if let existing = existingRoute {
+            existing.name = name
+            existing.routeType = routeType
+            existing.routeDescription = routeDescription
+            existing.startDayNumber = Int(startDayText)
+            existing.endDayNumber = Int(endDayText)
+            existing.segmentName = segmentName
+            existing.distanceMeters = Double(distanceText)
+            existing.estimatedHours = Double(estimatedHoursText)
+            existing.elevationGainMeters = Double(elevationGainText)
+            existing.elevationLossMeters = Double(elevationLossText)
+            existing.difficultyRating = difficultyRating
+            existing.terrainDescription = terrainDescription
+            existing.hazards = hazards
+            existing.requiredGear = requiredGear
+            existing.seasonalNotes = seasonalNotes
+            existing.destinationType = destinationType
+            existing.destinationName = destinationName
+            existing.destinationLatitude = Double(destLatText)
+            existing.destinationLongitude = Double(destLonText)
+            existing.nearestMedicalFacility = nearestMedicalFacility
+            existing.medicalFacilityDistance = medicalFacilityDistance
+            existing.communicationNotes = communicationNotes
+            existing.isVerified = isVerified
+            if isVerified { existing.lastVerifiedDate = Date() }
+            existing.notes = notes
+
+            viewModel.updateRoute(existing, in: expedition)
+        } else {
+            let route = EscapeRoute(name: name, routeType: routeType, segmentName: segmentName)
+            route.routeDescription = routeDescription
+            route.startDayNumber = Int(startDayText)
+            route.endDayNumber = Int(endDayText)
+            route.distanceMeters = Double(distanceText)
+            route.estimatedHours = Double(estimatedHoursText)
+            route.elevationGainMeters = Double(elevationGainText)
+            route.elevationLossMeters = Double(elevationLossText)
+            route.difficultyRating = difficultyRating
+            route.terrainDescription = terrainDescription
+            route.hazards = hazards
+            route.requiredGear = requiredGear
+            route.seasonalNotes = seasonalNotes
+            route.destinationType = destinationType
+            route.destinationName = destinationName
+            route.destinationLatitude = Double(destLatText)
+            route.destinationLongitude = Double(destLonText)
+            route.nearestMedicalFacility = nearestMedicalFacility
+            route.medicalFacilityDistance = medicalFacilityDistance
+            route.communicationNotes = communicationNotes
+            route.isVerified = isVerified
+            if isVerified { route.lastVerifiedDate = Date() }
+            route.notes = notes
+
+            viewModel.addRoute(route, to: expedition)
+        }
+
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    private func deleteWaypoints(at indexSet: IndexSet, from route: EscapeRoute) {
+        let sorted = route.sortedWaypoints
+        for index in indexSet {
+            viewModel.deleteWaypoint(sorted[index], from: route)
+        }
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteListView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteListView.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+import SwiftData
+
+struct EscapeRouteListView: View {
+    @Environment(\.modelContext)
+    private var modelContext
+    @Bindable var expedition: Expedition
+
+    @State private var viewModel: EscapeRouteViewModel?
+    @State private var showingAddSheet = false
+    @State private var selectedRoute: EscapeRoute?
+
+    var body: some View {
+        Group {
+            if let viewModel = viewModel {
+                routeList(viewModel: viewModel)
+            } else {
+                ProgressView()
+            }
+        }
+        .navigationTitle("Escape Routes")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingAddSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+
+            if let viewModel = viewModel, !viewModel.routes.isEmpty {
+                ToolbarItem(placement: .topBarLeading) {
+                    filterMenu(viewModel: viewModel)
+                }
+            }
+        }
+        .searchable(
+            text: Binding(
+                get: { viewModel?.searchText ?? "" },
+                set: { newValue in
+                    viewModel?.searchText = newValue
+                    viewModel?.loadRoutes(for: expedition)
+                }
+            ),
+            prompt: "Search routes"
+        )
+        .sheet(isPresented: $showingAddSheet) {
+            if let viewModel = viewModel {
+                NavigationStack {
+                    EscapeRouteFormView(
+                        mode: .create,
+                        expedition: expedition,
+                        viewModel: viewModel
+                    )
+                }
+            }
+        }
+        .sheet(item: $selectedRoute) { route in
+            if let viewModel = viewModel {
+                NavigationStack {
+                    EscapeRouteDetailView(
+                        route: route,
+                        expedition: expedition,
+                        viewModel: viewModel
+                    )
+                }
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = EscapeRouteViewModel(modelContext: modelContext)
+            }
+            viewModel?.loadRoutes(for: expedition)
+        }
+    }
+
+    // MARK: - List Content
+
+    @ViewBuilder
+    private func routeList(viewModel: EscapeRouteViewModel) -> some View {
+        if viewModel.routes.isEmpty && !viewModel.hasActiveFilters {
+            ContentUnavailableView {
+                Label("No Escape Routes", systemImage: "arrow.uturn.backward.circle")
+            } description: {
+                Text("Add escape routes to plan bailout options for each expedition segment.")
+            } actions: {
+                Button("Add Escape Route") {
+                    showingAddSheet = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } else if viewModel.routes.isEmpty {
+            ContentUnavailableView.search(text: viewModel.searchText)
+        } else {
+            List {
+                // Summary section
+                Section {
+                    summaryView(viewModel: viewModel)
+                }
+
+                // Filter indicator
+                if viewModel.hasActiveFilters {
+                    Section {
+                        filterIndicator(viewModel: viewModel)
+                    }
+                }
+
+                // Grouped by route type
+                ForEach(viewModel.groupedByType, id: \.routeType) { group in
+                    Section {
+                        ForEach(group.routes) { route in
+                            EscapeRouteRowView(route: route)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    selectedRoute = route
+                                }
+                        }
+                        .onDelete { indexSet in
+                            deleteRoutes(at: indexSet, from: group.routes, viewModel: viewModel)
+                        }
+                    } header: {
+                        HStack {
+                            Image(systemName: group.routeType.icon)
+                            Text(group.routeType.rawValue)
+                            Text("(\(group.routes.count))")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Summary View
+
+    private func summaryView(viewModel: EscapeRouteViewModel) -> some View {
+        HStack(spacing: 16) {
+            EscapeRouteStatBadge(
+                value: "\(viewModel.routes.count)",
+                label: "Total",
+                icon: "arrow.uturn.backward.circle",
+                color: .blue
+            )
+            EscapeRouteStatBadge(
+                value: "\(viewModel.primaryRoutes.count)",
+                label: "Primary",
+                icon: "arrow.uturn.backward.circle.fill",
+                color: .green
+            )
+            EscapeRouteStatBadge(
+                value: "\(viewModel.unverifiedCount)",
+                label: "Unverified",
+                icon: "questionmark.circle",
+                color: .orange
+            )
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Filter Indicator
+
+    private func filterIndicator(viewModel: EscapeRouteViewModel) -> some View {
+        HStack {
+            Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                .foregroundStyle(.blue)
+            Text(filterDescription(viewModel: viewModel))
+                .font(.subheadline)
+            Spacer()
+            Button("Clear") {
+                viewModel.clearFilters()
+                viewModel.loadRoutes(for: expedition)
+            }
+            .font(.caption)
+            .foregroundStyle(.blue)
+        }
+    }
+
+    private func filterDescription(viewModel: EscapeRouteViewModel) -> String {
+        var parts: [String] = []
+        if let routeType = viewModel.filterRouteType {
+            parts.append(routeType.rawValue)
+        }
+        if viewModel.showUnverifiedOnly {
+            parts.append("Unverified")
+        }
+        if !viewModel.searchText.isEmpty {
+            parts.append("\"\(viewModel.searchText)\"")
+        }
+        return parts.isEmpty ? "Filtered" : parts.joined(separator: " - ")
+    }
+
+    // MARK: - Filter Menu
+
+    @ViewBuilder
+    private func filterMenu(viewModel: EscapeRouteViewModel) -> some View {
+        Menu {
+            Button {
+                viewModel.clearFilters()
+                viewModel.loadRoutes(for: expedition)
+            } label: {
+                Label(
+                    "Clear Filters",
+                    systemImage: viewModel.hasActiveFilters ? "" : "checkmark"
+                )
+            }
+
+            Divider()
+
+            // Route type filter
+            Menu("Route Type") {
+                Button {
+                    viewModel.filterRouteType = nil
+                    viewModel.loadRoutes(for: expedition)
+                } label: {
+                    Label("All Types", systemImage: viewModel.filterRouteType == nil ? "checkmark" : "")
+                }
+
+                Divider()
+
+                ForEach(EscapeRouteType.allCases, id: \.self) { routeType in
+                    Button {
+                        viewModel.filterRouteType = routeType
+                        viewModel.loadRoutes(for: expedition)
+                    } label: {
+                        Label {
+                            Text(routeType.rawValue)
+                        } icon: {
+                            if viewModel.filterRouteType == routeType {
+                                Image(systemName: "checkmark")
+                            } else {
+                                Image(systemName: routeType.icon)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            // Unverified toggle
+            Toggle("Unverified Only", isOn: Binding(
+                get: { viewModel.showUnverifiedOnly },
+                set: { newValue in
+                    viewModel.showUnverifiedOnly = newValue
+                    viewModel.loadRoutes(for: expedition)
+                }
+            ))
+
+            Divider()
+
+            // Sort options
+            Menu("Sort By") {
+                ForEach(EscapeRouteSortOrder.allCases, id: \.self) { order in
+                    Button {
+                        viewModel.sortOrder = order
+                        viewModel.loadRoutes(for: expedition)
+                    } label: {
+                        Label(
+                            order.rawValue,
+                            systemImage: viewModel.sortOrder == order ? "checkmark" : ""
+                        )
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: viewModel.hasActiveFilters
+                ? "line.3.horizontal.decrease.circle.fill"
+                : "line.3.horizontal.decrease.circle")
+        }
+    }
+
+    // MARK: - Delete
+
+    private func deleteRoutes(
+        at indexSet: IndexSet,
+        from routes: [EscapeRoute],
+        viewModel: EscapeRouteViewModel
+    ) {
+        for index in indexSet {
+            viewModel.deleteRoute(routes[index], from: expedition)
+        }
+    }
+}
+
+// MARK: - Stat Badge
+
+struct EscapeRouteStatBadge: View {
+    let value: String
+    let label: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(color)
+            Text(value)
+                .font(.headline)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteRowView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeRouteRowView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct EscapeRouteRowView: View {
+    let route: EscapeRoute
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Route type indicator
+            VStack {
+                Image(systemName: route.routeType.icon)
+                    .font(.title2)
+                    .foregroundStyle(colorForType)
+            }
+            .frame(width: 40, height: 40)
+            .background(colorForType.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            // Content
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(route.name)
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    if route.isVerified {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    if let dayRange = route.dayRangeDescription {
+                        Text(dayRange)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !route.destinationName.isEmpty {
+                        Label(route.destinationName, systemImage: route.destinationType.icon)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Distance and time
+            VStack(alignment: .trailing, spacing: 2) {
+                if let distance = route.distance {
+                    Text(formatDistance(distance))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+                if let time = route.formattedEstimatedTime {
+                    Text(time)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var colorForType: Color {
+        switch route.routeType.color {
+        case "green": return .green
+        case "orange": return .orange
+        case "red": return .red
+        default: return .secondary
+        }
+    }
+
+    private func formatDistance(_ distance: Measurement<UnitLength>) -> String {
+        let km = distance.converted(to: .kilometers)
+        if km.value < 1 {
+            let meters = distance.converted(to: .meters)
+            return String(format: "%.0f m", meters.value)
+        }
+        return String(format: "%.1f km", km.value)
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeWaypointFormView.swift
+++ b/ExpeditionPlanner/ExpeditionPlanner/Views/Safety/EscapeWaypointFormView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+enum EscapeWaypointFormMode {
+    case create
+    case edit(EscapeWaypoint)
+}
+
+struct EscapeWaypointFormView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let mode: EscapeWaypointFormMode
+    let onSave: (EscapeWaypoint) -> Void
+
+    @State private var name: String = ""
+    @State private var latitudeText: String = ""
+    @State private var longitudeText: String = ""
+    @State private var elevationText: String = ""
+    @State private var waypointDescription: String = ""
+    @State private var hazards: String = ""
+    @State private var notes: String = ""
+
+    private var isEditing: Bool {
+        if case .edit = mode { return true }
+        return false
+    }
+
+    private var existingWaypoint: EscapeWaypoint? {
+        if case .edit(let waypoint) = mode {
+            return waypoint
+        }
+        return nil
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Name", text: $name)
+
+                TextField("Latitude", text: $latitudeText)
+                    .keyboardType(.decimalPad)
+
+                TextField("Longitude", text: $longitudeText)
+                    .keyboardType(.decimalPad)
+
+                TextField("Elevation (meters)", text: $elevationText)
+                    .keyboardType(.decimalPad)
+            } header: {
+                Text("Waypoint Info")
+            }
+
+            Section {
+                VStack(alignment: .leading) {
+                    Text("Description")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $waypointDescription)
+                        .frame(minHeight: 60)
+                }
+
+                VStack(alignment: .leading) {
+                    Text("Hazards")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $hazards)
+                        .frame(minHeight: 60)
+                }
+            } header: {
+                Text("Details")
+            }
+
+            Section {
+                VStack(alignment: .leading) {
+                    Text("Notes")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $notes)
+                        .frame(minHeight: 40)
+                }
+            } header: {
+                Text("Notes")
+            }
+        }
+        .navigationTitle(isEditing ? "Edit Waypoint" : "New Waypoint")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") {
+                    dismiss()
+                }
+            }
+
+            ToolbarItem(placement: .confirmationAction) {
+                Button(isEditing ? "Save" : "Add") {
+                    saveWaypoint()
+                }
+                .disabled(name.isEmpty)
+            }
+        }
+        .onAppear {
+            loadExistingData()
+        }
+    }
+
+    private func loadExistingData() {
+        guard let waypoint = existingWaypoint else { return }
+
+        name = waypoint.name
+        if let lat = waypoint.latitude {
+            latitudeText = String(lat)
+        }
+        if let lon = waypoint.longitude {
+            longitudeText = String(lon)
+        }
+        if let elev = waypoint.elevationMeters {
+            elevationText = String(elev)
+        }
+        waypointDescription = waypoint.waypointDescription
+        hazards = waypoint.hazards
+        notes = waypoint.notes
+    }
+
+    private func saveWaypoint() {
+        if let existing = existingWaypoint {
+            existing.name = name
+            existing.latitude = Double(latitudeText)
+            existing.longitude = Double(longitudeText)
+            existing.elevationMeters = Double(elevationText)
+            existing.waypointDescription = waypointDescription
+            existing.hazards = hazards
+            existing.notes = notes
+            onSave(existing)
+        } else {
+            let waypoint = EscapeWaypoint(name: name)
+            waypoint.latitude = Double(latitudeText)
+            waypoint.longitude = Double(longitudeText)
+            waypoint.elevationMeters = Double(elevationText)
+            waypoint.waypointDescription = waypointDescription
+            waypoint.hazards = hazards
+            waypoint.notes = notes
+            onSave(waypoint)
+        }
+
+        dismiss()
+    }
+}

--- a/ExpeditionPlanner/ExpeditionPlannerTests/EscapeRouteTests.swift
+++ b/ExpeditionPlanner/ExpeditionPlannerTests/EscapeRouteTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+import SwiftData
+@testable import Chaki
+
+final class EscapeRouteTests: XCTestCase {
+
+    // MARK: - Creation Tests
+
+    func testEscapeRouteCreation() throws {
+        let route = EscapeRoute(
+            name: "River Crossing Bailout",
+            routeType: .primary,
+            segmentName: "Day 3-5 Ridge"
+        )
+
+        XCTAssertNotNil(route.id)
+        XCTAssertEqual(route.name, "River Crossing Bailout")
+        XCTAssertEqual(route.routeType, .primary)
+        XCTAssertEqual(route.segmentName, "Day 3-5 Ridge")
+    }
+
+    func testEscapeRouteDefaultValues() throws {
+        let route = EscapeRoute(name: "Test Route")
+
+        XCTAssertEqual(route.routeType, .primary)
+        XCTAssertEqual(route.difficultyRating, .moderate)
+        XCTAssertEqual(route.destinationType, .trailhead)
+        XCTAssertFalse(route.isVerified)
+        XCTAssertTrue(route.routeDescription.isEmpty)
+        XCTAssertTrue(route.hazards.isEmpty)
+        XCTAssertNil(route.distanceMeters)
+        XCTAssertNil(route.estimatedHours)
+        XCTAssertNil(route.startDayNumber)
+        XCTAssertNil(route.endDayNumber)
+    }
+
+    // MARK: - Computed Property Tests
+
+    func testDistanceComputed() throws {
+        let route = EscapeRoute(name: "Test")
+        route.distanceMeters = 5000
+
+        let distance = route.distance
+        XCTAssertNotNil(distance)
+        XCTAssertEqual(distance?.value, 5000)
+        XCTAssertEqual(distance?.unit, .meters)
+    }
+
+    func testDistanceNilWhenNotSet() throws {
+        let route = EscapeRoute(name: "Test")
+
+        XCTAssertNil(route.distance)
+    }
+
+    func testFormattedEstimatedTimeHoursAndMinutes() throws {
+        let route = EscapeRoute(name: "Test")
+        route.estimatedHours = 6.5
+
+        XCTAssertEqual(route.formattedEstimatedTime, "6h 30m")
+    }
+
+    func testFormattedEstimatedTimeWholeHours() throws {
+        let route = EscapeRoute(name: "Test")
+        route.estimatedHours = 3.0
+
+        XCTAssertEqual(route.formattedEstimatedTime, "3h")
+    }
+
+    func testFormattedEstimatedTimeMinutesOnly() throws {
+        let route = EscapeRoute(name: "Test")
+        route.estimatedHours = 0.75
+
+        XCTAssertEqual(route.formattedEstimatedTime, "45m")
+    }
+
+    func testFormattedEstimatedTimeNil() throws {
+        let route = EscapeRoute(name: "Test")
+
+        XCTAssertNil(route.formattedEstimatedTime)
+    }
+
+    func testDestinationCoordinate() throws {
+        let route = EscapeRoute(name: "Test")
+        route.destinationLatitude = 65.5
+        route.destinationLongitude = -150.2
+
+        let coord = route.destinationCoordinate
+        XCTAssertNotNil(coord)
+        XCTAssertEqual(coord?.latitude, 65.5)
+        XCTAssertEqual(coord?.longitude, -150.2)
+    }
+
+    func testDayRangeDescriptionRange() throws {
+        let route = EscapeRoute(name: "Test")
+        route.startDayNumber = 3
+        route.endDayNumber = 5
+
+        XCTAssertEqual(route.dayRangeDescription, "Days 3-5")
+    }
+
+    func testDayRangeDescriptionSingleDay() throws {
+        let route = EscapeRoute(name: "Test")
+        route.startDayNumber = 7
+        route.endDayNumber = 7
+
+        XCTAssertEqual(route.dayRangeDescription, "Day 7")
+    }
+
+    func testDayRangeDescriptionStartOnly() throws {
+        let route = EscapeRoute(name: "Test")
+        route.startDayNumber = 4
+
+        XCTAssertEqual(route.dayRangeDescription, "Day 4")
+    }
+
+    func testDayRangeDescriptionNil() throws {
+        let route = EscapeRoute(name: "Test")
+
+        XCTAssertNil(route.dayRangeDescription)
+    }
+
+    func testSortedWaypoints() throws {
+        let route = EscapeRoute(name: "Test")
+        let wp1 = EscapeWaypoint(name: "Second", orderIndex: 1)
+        let wp2 = EscapeWaypoint(name: "First", orderIndex: 0)
+        let wp3 = EscapeWaypoint(name: "Third", orderIndex: 2)
+        route.waypoints = [wp1, wp2, wp3]
+
+        let sorted = route.sortedWaypoints
+        XCTAssertEqual(sorted[0].name, "First")
+        XCTAssertEqual(sorted[1].name, "Second")
+        XCTAssertEqual(sorted[2].name, "Third")
+    }
+
+    // MARK: - EscapeWaypoint Tests
+
+    func testEscapeWaypointCreation() throws {
+        let waypoint = EscapeWaypoint(name: "River Ford", orderIndex: 2)
+
+        XCTAssertNotNil(waypoint.id)
+        XCTAssertEqual(waypoint.name, "River Ford")
+        XCTAssertEqual(waypoint.orderIndex, 2)
+    }
+
+    func testEscapeWaypointCoordinate() throws {
+        let waypoint = EscapeWaypoint(name: "Test")
+        waypoint.latitude = 64.8
+        waypoint.longitude = -148.3
+
+        let coord = waypoint.coordinate
+        XCTAssertNotNil(coord)
+        XCTAssertEqual(coord?.latitude, 64.8)
+        XCTAssertEqual(coord?.longitude, -148.3)
+    }
+
+    func testEscapeWaypointElevation() throws {
+        let waypoint = EscapeWaypoint(name: "Test")
+        waypoint.elevationMeters = 1500
+
+        let elevation = waypoint.elevation
+        XCTAssertNotNil(elevation)
+        XCTAssertEqual(elevation?.value, 1500)
+        XCTAssertEqual(elevation?.unit, .meters)
+    }
+
+    // MARK: - Enum Tests
+
+    func testEscapeRouteTypeProperties() throws {
+        for type in EscapeRouteType.allCases {
+            XCTAssertFalse(type.icon.isEmpty)
+            XCTAssertFalse(type.color.isEmpty)
+        }
+    }
+
+    func testEscapeRouteTypeSortOrder() throws {
+        XCTAssertEqual(EscapeRouteType.primary.sortOrder, 0)
+        XCTAssertEqual(EscapeRouteType.alternate.sortOrder, 1)
+        XCTAssertEqual(EscapeRouteType.emergencyOnly.sortOrder, 2)
+    }
+
+    func testEscapeDestinationTypeProperties() throws {
+        for type in EscapeDestinationType.allCases {
+            XCTAssertFalse(type.icon.isEmpty)
+        }
+    }
+
+    func testDifficultyRatingProperties() throws {
+        for rating in DifficultyRating.allCases {
+            XCTAssertFalse(rating.icon.isEmpty)
+            XCTAssertFalse(rating.color.isEmpty)
+        }
+    }
+
+    func testEscapeRouteTypeCaseCount() throws {
+        XCTAssertEqual(EscapeRouteType.allCases.count, 3)
+    }
+
+    func testDestinationTypeCaseCount() throws {
+        XCTAssertEqual(EscapeDestinationType.allCases.count, 8)
+    }
+
+    func testDifficultyRatingCaseCount() throws {
+        XCTAssertEqual(DifficultyRating.allCases.count, 5)
+    }
+
+    // MARK: - Persistence Test
+
+    @MainActor
+    func testSwiftDataPersistence() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: Expedition.self, EscapeRoute.self, EscapeWaypoint.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let expedition = Expedition(name: "Test Expedition")
+        context.insert(expedition)
+
+        let route = EscapeRoute(name: "Ridge Bailout", routeType: .primary)
+        route.distanceMeters = 8000
+        route.estimatedHours = 4.5
+        route.destinationName = "Anaktuvuk Pass"
+        route.expedition = expedition
+        context.insert(route)
+
+        let waypoint = EscapeWaypoint(name: "Saddle Pass", orderIndex: 0)
+        waypoint.latitude = 68.1
+        waypoint.longitude = -151.7
+        waypoint.escapeRoute = route
+        context.insert(waypoint)
+
+        try context.save()
+
+        let descriptor = FetchDescriptor<EscapeRoute>()
+        let fetched = try context.fetch(descriptor)
+
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.name, "Ridge Bailout")
+        XCTAssertEqual(fetched.first?.distanceMeters, 8000)
+        XCTAssertEqual(fetched.first?.waypoints?.count, 1)
+        XCTAssertEqual(fetched.first?.waypoints?.first?.name, "Saddle Pass")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EscapeRoute` and `EscapeWaypoint` SwiftData models with 3 enums (`EscapeRouteType`, `EscapeDestinationType`, `DifficultyRating`) for pre-planned emergency bailout options tied to itinerary day ranges
- Implement full CRUD views (list, detail, form, row) and `EscapeRouteViewModel` with filtering, sorting, and waypoint management, following the existing `RiskAssessment` pattern in the Safety module
- Integrate escape routes into `ExpeditionDetailView` Safety section with navigation, and add 25 unit tests covering models, computed properties, enums, and SwiftData persistence

Closes #39

## Test plan
- [x] `swiftlint lint --quiet` — 0 violations
- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — 245 tests pass (25 new EscapeRoute tests)
- [ ] Manual: create expedition → Safety → Escape Routes → add/edit/delete routes and waypoints
- [ ] Manual: verify filtering by route type, unverified toggle, sort options, and search
- [ ] Manual: verify cascade delete removes routes when expedition is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)